### PR TITLE
ci: Display unified diff with what gofmt wants us to change

### DIFF
--- a/.ci/go-static-checks.sh
+++ b/.ci/go-static-checks.sh
@@ -79,7 +79,7 @@ echo "Running go vet..."
 go vet $go_packages
 
 echo "Running gofmt..."
-gofmt -s -l $go_files | tee /dev/tty | \
+gofmt -s -d -l $go_files | tee /dev/tty | \
     wc -l | xargs -I % bash -c "test % -eq 0"
 
 echo "Running cyclo..."


### PR DESCRIPTION
We run gofmt with the simplify (-s) option. Some of the rewrite rules
are hidden behind that flag because they break previous go versions.
Editors don't run gofmt with -s by default for that reason and so it's
not unlikely the static checks scripts find something to change.

We can do better than displaying the list of "offending" files, we can
make gofmt display a unified diff with the suggested simplification.
It's just a matter of using the -d flag.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>