### PR TITLE
exec should wait for shim

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/clearcontainers/proxy/api"
 	goapi "github.com/clearcontainers/proxy/client"
@@ -403,6 +404,12 @@ func TestHyperSequenceNumberRelocation(t *testing.T) {
 	tokens := ret.IO.Tokens
 	assert.Equal(t, 1, len(tokens))
 
+	// Create a new connection for the shim and register it.
+	shimConn := rig.ServeNewClient()
+	shim := newShimRig(t, shimConn, tokens[0])
+	err = shim.connect()
+	assert.Nil(t, err)
+
 	// Send newcontainer hyper command
 	newcontainer := hyperstart.Container{
 		ID: testContainerID,
@@ -424,6 +431,7 @@ func TestHyperSequenceNumberRelocation(t *testing.T) {
 	assert.NotEqual(t, 0, payload.Process.Stdio)
 	assert.NotEqual(t, 0, payload.Process.Stderr)
 
+	shim.close()
 	rig.Stop()
 }
 
@@ -590,6 +598,63 @@ func TestShimSignal(t *testing.T) {
 	assert.Equal(t, session.ioBase, decoded1.Seq)
 	assert.Equal(t, uint16(42), decoded1.Column)
 	assert.Equal(t, uint16(24), decoded1.Row)
+
+	// Cleanup
+	shim.close()
+
+	rig.Stop()
+}
+
+// smallWaitForShimTimeout overrides the default timeout for the tests
+const smallWaitForShimTimeout = 20 * time.Millisecond
+
+// TestShimConnectAfterExeccmd tests we correctly wait for the shim to connect
+// before forwarding the execcmd to hyperstart.
+func TestShimConnectAfterExeccmd(t *testing.T) {
+	rig := newTestRig(t)
+	rig.Start()
+
+	// Register new VM, asking for tokens. We use the assumption the same
+	// connection can be used for ConnectShim, which is true in the tests.:62
+	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
+	ret, err := rig.Client.RegisterVM(testContainerID, ctlSocketPath, ioSocketPath,
+		&goapi.RegisterVMOptions{NumIOStreams: 1})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(ret.IO.Tokens))
+	tokens := ret.IO.Tokens
+
+	// Send an execcmd. Since we don't have the corresponding shim yet, this
+	// should time out.
+	oldTimeout := waitForShimTimeout
+	waitForShimTimeout = smallWaitForShimTimeout
+	execcmd := hyperstart.ExecCommand{
+		Container: testContainerID,
+		Process: hyperstart.Process{
+			Args: []string{"/bin/sh"},
+		},
+	}
+	err = rig.Client.HyperWithTokens("execcmd", tokens, &execcmd)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "timeout"))
+	waitForShimTimeout = oldTimeout
+
+	// Send an execcmd again, but this time will connect the shim just after the command.
+	shimConn := rig.ServeNewClient()
+	shim := newShimRig(t, shimConn, tokens[0])
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		time.Sleep(smallWaitForShimTimeout)
+		err := shim.connect()
+		assert.Nil(t, err)
+		wg.Done()
+	}()
+
+	err = rig.Client.HyperWithTokens("execcmd", tokens, &execcmd)
+	assert.Nil(t, err)
+
+	wg.Wait()
 
 	// Cleanup
 	shim.close()

--- a/vm_test.go
+++ b/vm_test.go
@@ -128,6 +128,9 @@ func TestHyperRelocationNewcontainer(t *testing.T) {
 	// 1 process can be spawned using execcmd.
 	cmd := rig.createNewcontainer(vm, 1)
 	token := cmd.Tokens[0]
+	// associate a dummy shim
+	vm.AssociateShim(Token(token), 1, nil)
+	// relocate
 	err := vm.relocateHyperCommand(cmd)
 	assert.Nil(t, err)
 
@@ -176,6 +179,9 @@ func TestHyperRelocationExeccmd(t *testing.T) {
 	// 1 process can be spawned using execcmd.
 	cmd := rig.createExecmd(vm, 1)
 	token := cmd.Tokens[0]
+	// associate a dummy shim
+	vm.AssociateShim(Token(token), 1, nil)
+	// relocate
 	err := vm.relocateHyperCommand(cmd)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
    I don't really want to have to queue stdout/err data in the proxy.
    
    To solve that, let's introduce a new constraint. The data path:
    
      shim <-> proxy <-> hyperstart
    
    has to be fully setup before we allow newcontainer/execmd to execute a
    new process. While we advise to start the shim as early as possible and
    issue the newcontainer/execcmd command after that, we need to
    synchronize somewhere. The easier way of doing that is to stall the
    newcontainer/execcmd commands until we see the corresponding shim
    registering itself.
    
    Fixes: https://github.com/clearcontainers/proxy/issues/21
    Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>
