### PR TITLE
proxy: Always return valid URL

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -113,8 +113,15 @@ func (c *client) infof(lvl glog.Level, fmt string, a ...interface{}) {
 }
 
 func (proxy *proxy) allocateTokens(vm *vm, numIOStreams int) (*api.IOResponse, error) {
+	url := url.URL{
+		Scheme: "unix",
+		Path:   proxy.socketPath,
+	}
+
 	if numIOStreams <= 0 {
-		return nil, nil
+		return &api.IOResponse{
+			URL: url.String(),
+		}, nil
 	}
 
 	tokens := make([]string, 0, numIOStreams)
@@ -131,11 +138,6 @@ func (proxy *proxy) allocateTokens(vm *vm, numIOStreams int) (*api.IOResponse, e
 			vm:    vm,
 		}
 		proxy.Unlock()
-	}
-
-	url := url.URL{
-		Scheme: "unix",
-		Path:   proxy.socketPath,
 	}
 
 	return &api.IOResponse{

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -156,7 +156,6 @@ func TestRegisterVM(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, ret)
 	// We haven't asked for I/O tokens
-	assert.Equal(t, "", ret.IO.URL)
 	assert.Equal(t, 0, len(ret.IO.Tokens))
 
 	// A new RegisterVM message with the same containerID should error out.
@@ -234,7 +233,6 @@ func TestAttachVM(t *testing.T) {
 	ret, err := rig.Client.AttachVM(testContainerID, nil)
 	assert.Nil(t, err)
 	// We haven't asked for I/O tokens
-	assert.Equal(t, "", ret.IO.URL)
 	assert.Equal(t, 0, len(ret.IO.Tokens))
 
 	err = rig.Client.UnregisterVM(testContainerID)


### PR DESCRIPTION
Even when we are not allocating some IO streams, the caller can expect to receive a valid URL.