### PR TITLE
vm: Allow newcontainer and execcmd without an I/O token

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -337,8 +337,14 @@ func (vm *vm) relocateHyperCommand(hyper *api.Hyper) error {
 
 	for _, cmd := range cmds {
 		if hyper.HyperName == cmd.name {
-			if nTokens != 1 {
-				return fmt.Errorf("expected 1 token, got %d", nTokens)
+			if nTokens > 1 {
+				return fmt.Errorf("expected 0 or 1 token, got %d", nTokens)
+			}
+
+			// We don't need a token to start a process inside the VM, but we
+			// don't get a session in that case.
+			if nTokens == 0 {
+				continue
 			}
 
 			token := hyper.Tokens[0]

--- a/vm_test.go
+++ b/vm_test.go
@@ -143,17 +143,36 @@ func TestHyperRelocationNewcontainer(t *testing.T) {
 	assert.Equal(t, session.ioBase, cmdOut.Process.Stdio)
 	assert.Equal(t, session.ioBase+1, cmdOut.Process.Stderr)
 
-	// Giving other fewer or more tokens than 1 should result in an error
-	cmd = rig.createNewcontainer(vm, 0)
-	err = vm.relocateHyperCommand(cmd)
-	assert.NotNil(t, err)
-
-	cmd = rig.createNewcontainer(vm, 2)
+	// Giving more than 1 token should result in an error
+	cmd = rig.createExecmd(vm, 2)
 	err = vm.relocateHyperCommand(cmd)
 	assert.NotNil(t, err)
 
 	rig.Stop()
 
+	vm.Close()
+}
+
+// In some case, we want to create containers without caring about the session
+// between the process inside the VM and the host. One of those cases is the
+// pause container created as we create a pod in virtcontainers.
+func TestHyperRelocationNewcontainerNoToken(t *testing.T) {
+	rig := newVMRig(t)
+	rig.Start()
+
+	vm := rig.CreateVM()
+
+	// Relocate an execcmd command, no token given!
+	cmd := rig.createNewcontainer(vm, 0)
+
+	// don't associate a dummy shim, we should wait for one when no token is
+	// given.
+
+	// relocate
+	err := vm.relocateHyperCommand(cmd)
+	assert.Nil(t, err)
+
+	rig.Stop()
 	vm.Close()
 }
 
@@ -194,11 +213,7 @@ func TestHyperRelocationExeccmd(t *testing.T) {
 	assert.Equal(t, session.ioBase, cmdOut.Process.Stdio)
 	assert.Equal(t, session.ioBase+1, cmdOut.Process.Stderr)
 
-	// Giving other fewer or more tokens than 1 should result in an error
-	cmd = rig.createExecmd(vm, 0)
-	err = vm.relocateHyperCommand(cmd)
-	assert.NotNil(t, err)
-
+	// Giving more than 1 token should result in an error
 	cmd = rig.createExecmd(vm, 2)
 	err = vm.relocateHyperCommand(cmd)
 	assert.NotNil(t, err)


### PR DESCRIPTION
In some cases, we don't need to communicate with the process inside the
VM and don't care about its stdout/err for instance.

This is the case for the pause container when creating a pod with
virtcontainers.

Fixes: https://github.com/clearcontainers/proxy/issues/32
Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>