### PR TITLE
vm: Introduce a null session for executions without tokens

### DIFF
--- a/vm_test.go
+++ b/vm_test.go
@@ -172,6 +172,15 @@ func TestHyperRelocationNewcontainerNoToken(t *testing.T) {
 	err := vm.relocateHyperCommand(cmd)
 	assert.Nil(t, err)
 
+	// Check that the relocated command contains the seq numbers
+	// of the null session
+	session := &vm.nullSession
+	cmdOut := hyperstart.ExecCommand{}
+	err = json.Unmarshal(cmd.Data, &cmdOut)
+	assert.Nil(t, err)
+	assert.Equal(t, session.ioBase, cmdOut.Process.Stdio)
+	assert.Equal(t, session.ioBase+1, cmdOut.Process.Stderr)
+
 	rig.Stop()
 	vm.Close()
 }


### PR DESCRIPTION
In:

  commit 316d6e2acee64c0f55db138a47e0aed4e1ebb955
  Author: Damien Lespiau <damien.lespiau@intel.com>
  Date:   Wed Apr 12 18:39:26 2017 +0100

      vm: Allow newcontainer and execcmd without an I/O token

We tried to not associate a session (and the corresponding hyperstart
sequence numbers) to containers for which we don't want to send stdin
nor receive stdout/stderr data.

Unfortunately, hyperstart requires us to provide a sequence number. To
work around that, we create a "null session" for every VM with its own
sequence numbers. The proxy will not allocate a Token for null sessions
(no shim can ever try to claim that session) and will discard data of
processes using that null session.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>