### PR TITLE
cc-proxy: Fix systemd socket and service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LIBEXECDIR := $(PREFIX)/libexec
 LOCALSTATEDIR := /var
 
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.(c|h|go)$$')
-PROXY_SOCKET := $(LOCALSTATEDIR)/run/clearcontainers/proxy.sock
+PROXY_SOCKET := $(LOCALSTATEDIR)/run/clear-containers/proxy.sock
 
 #
 # systemd files
@@ -77,7 +77,7 @@ endef
 all-installable: cc-proxy $(UNIT_FILES)
 
 install: all-installable
-	$(call INSTALL_EXEC,cc-proxy,$(LIBEXECDIR)/clearcontainers)
+	$(call INSTALL_EXEC,cc-proxy,$(LIBEXECDIR)/clear-containers)
 	$(foreach f,$(UNIT_FILES),$(call INSTALL_FILE,$f,$(UNIT_DIR)))
 
 clean:

--- a/cc-proxy.service.in
+++ b/cc-proxy.service.in
@@ -3,7 +3,7 @@ Description=Clear Containers Proxy
 Documentation=https://github.com/clearcontainers/proxy
 
 [Service]
-ExecStart=@libexecdir@/cc-proxy
+ExecStart=@libexecdir@/clearcontainers/cc-proxy
 
 [Install]
 WantedBy=multi-user.target

--- a/cc-proxy.service.in
+++ b/cc-proxy.service.in
@@ -3,7 +3,7 @@ Description=Clear Containers Proxy
 Documentation=https://github.com/clearcontainers/proxy
 
 [Service]
-ExecStart=@libexecdir@/clearcontainers/cc-proxy
+ExecStart=@libexecdir@/clear-containers/cc-proxy
 
 [Install]
 WantedBy=multi-user.target

--- a/cc-proxy.socket.in
+++ b/cc-proxy.socket.in
@@ -4,7 +4,7 @@ Documentation=https://github.com/clearcontainers/proxy
 PartOf=cc-proxy.service
 
 [Socket]
-ListenStream=@localstatedir@/run/clearcontainers/proxy.sock
+ListenStream=@localstatedir@/run/clear-containers/proxy.sock
 DirectoryMode=0770
 SocketMode=0660
 

--- a/cc-proxy.socket.in
+++ b/cc-proxy.socket.in
@@ -4,7 +4,7 @@ Documentation=https://github.com/clearcontainers/proxy
 PartOf=cc-proxy.service
 
 [Socket]
-ListenStream=@localstatedir@/run/cc-oci-runtime/proxy.sock
+ListenStream=@localstatedir@/run/clearcontainers/proxy.sock
 DirectoryMode=0770
 SocketMode=0660
 


### PR DESCRIPTION
Some paths provided in the cc-proxy.service and cc-proxy.socket were both relying on legacy path names from cc-oci-runtime. This directly led the cc-proxy service to be not started as expected when the proxy socket was used.