### PR TITLE
Make the shim wait for the process to be started before forwarding stdin and signals

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -301,3 +301,12 @@ func (client *Client) Kill(signal syscall.Signal) error {
 func (client *Client) SendTerminalSize(columns, rows int) error {
 	return client.signal(syscall.SIGWINCH, columns, rows)
 }
+
+func (client *Client) sendStream(op api.Stream, data []byte) error {
+	return api.WriteStream(client.conn, op, data)
+}
+
+// SendStdin sends stdin data. This can only be used from shim clients.
+func (client *Client) SendStdin(data []byte) error {
+	return client.sendStream(api.StreamStdin, data)
+}

--- a/proxy.go
+++ b/proxy.go
@@ -428,6 +428,12 @@ func signal(data []byte, userData interface{}, response *handlerResponse) {
 
 	client.log.Infof("Signal(%s,%d,%d)", signal, payload.Columns, payload.Rows)
 
+	// Wait for the process inside the VM to be started if needed.
+	if err := session.WaitForProcess(false); err != nil {
+		response.SetError(err)
+		return
+	}
+
 	var err error
 	if signal == syscall.SIGWINCH {
 		err = session.SendTerminalSize(payload.Columns, payload.Rows)

--- a/proxy.go
+++ b/proxy.go
@@ -537,6 +537,17 @@ func (proxy *proxy) serveNewClient(proto *protocol, newConn net.Conn) {
 		newClient.log.Errorf("error serving client: %v", err)
 	}
 
+	// The client was a shim with a session still alive. This means DisconnectShim
+	// hasn't been called and we're closing the connection because of an error
+	// (either us or the shim has closed the connection). We want to keep the
+	// session alive and hope a shim will reconnect claiming the same token.
+	if newClient.session != nil {
+		proxy.Lock()
+		info := proxy.tokenToVM[newClient.token]
+		info.state = tokenStateAllocated
+		proxy.Unlock()
+	}
+
 	newConn.Close()
 	newClient.log.Info("connection closed")
 }

--- a/vm.go
+++ b/vm.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -425,7 +426,9 @@ func (session *ioSession) WaitForShim() error {
 	select {
 	case <-session.shimConnected:
 	case <-time.After(waitForShimTimeout):
-		return fmt.Errorf("timeout waiting for shim with token %s", session.token)
+		msg := fmt.Sprintf("timeout waiting for shim with token %s", session.token)
+		session.vm.logIO.Error(msg)
+		return errors.New(msg)
 	}
 	return nil
 }

--- a/vm.go
+++ b/vm.go
@@ -95,6 +95,11 @@ type ioSession struct {
 	// commands newcontainer and execcmd will wait for the shim to be ready
 	// before forwarding the command to hyperstart)
 	shimConnected chan interface{}
+
+	// Channel to signal the process corresponding to that session has been
+	// started. This is used to stop the shim from sending stdin data to a
+	// non-existent process.
+	processStarted chan interface{}
 }
 
 const (
@@ -120,10 +125,11 @@ func newVM(id, ctlSerial, ioSerial string) *vm {
 	}
 
 	vm.nullSession = ioSession{
-		vm:            vm,
-		nStreams:      2,
-		ioBase:        nullSessionStdout,
-		shimConnected: make(chan interface{}),
+		vm:             vm,
+		nStreams:       2,
+		ioBase:         nullSessionStdout,
+		shimConnected:  make(chan interface{}),
+		processStarted: make(chan interface{}),
 	}
 	vm.ioSessions[nullSessionStdout] = &vm.nullSession
 	vm.ioSessions[nullSessionStderr] = &vm.nullSession
@@ -131,6 +137,17 @@ func newVM(id, ctlSerial, ioSerial string) *vm {
 	close(vm.nullSession.shimConnected)
 
 	return vm
+}
+
+// ResetShim resets the session state related to the shim. Call this when we
+// lose the connection to the shim, whether we close it ourselves or the shim
+// crashes and the connection is closed.
+func (session *ioSession) ResetShim() {
+	session.vm.logIO.Debug("lost the shim for %s", session.token)
+	if session == &session.vm.nullSession {
+		return
+	}
+	session.shimConnected = make(chan interface{})
 }
 
 // setConsole() will make the proxy output the console data on stderr
@@ -343,11 +360,16 @@ func newcontainerHandler(vm *vm, hyper *api.Hyper, session *ioSession) error {
 	return nil
 }
 
-// RelocateHyperCommand performs the sequence number relocation in the
+// relocateHyperCommand performs the sequence number relocation in the
 // newcontainer and execcmd hyper commands given the corresponding list of
 // tokens. Starpod isn't handled as it's not currently use to start processes
 // and indicated as deprecated in the hyperstart API.
-func (vm *vm) relocateHyperCommand(hyper *api.Hyper) error {
+// relocateHyperCommand will return the Session of the process in question if
+// the hyper command needed a relocation. This is the same thing as saying if
+// the hyper command is either newcontainer or execcmd.
+func (vm *vm) relocateHyperCommand(hyper *api.Hyper) (*ioSession, error) {
+	var session *ioSession
+
 	cmds := []struct {
 		name    string
 		handler relocationHandler
@@ -362,10 +384,9 @@ func (vm *vm) relocateHyperCommand(hyper *api.Hyper) error {
 	for _, cmd := range cmds {
 		if hyper.HyperName == cmd.name {
 			if nTokens > 1 {
-				return fmt.Errorf("expected 0 or 1 token, got %d", nTokens)
+				return nil, fmt.Errorf("expected 0 or 1 token, got %d", nTokens)
 			}
 
-			var session *ioSession
 			if nTokens == 0 {
 				// When not given any token, we use the nullSession and will discard data
 				// received from hyper
@@ -374,18 +395,18 @@ func (vm *vm) relocateHyperCommand(hyper *api.Hyper) error {
 				token := hyper.Tokens[0]
 				session = vm.findSessionByToken(Token(token))
 				if session == nil {
-					return fmt.Errorf("unknown token %s", token)
+					return nil, fmt.Errorf("unknown token %s", token)
 				}
 			}
 
 			if err := cmd.handler(vm, hyper, session); err != nil {
-				return err
+				return nil, err
 			}
 
 			// Wait for the corresponding shim to be registered with the proxy so we can
 			// start forwarding data as soon as we receive it
 			if err := session.WaitForShim(); err != nil {
-				return err
+				return nil, err
 			}
 
 			needsRelocation = true
@@ -396,20 +417,28 @@ func (vm *vm) relocateHyperCommand(hyper *api.Hyper) error {
 	// If a hyper command doesn't need a token but one is given anyway, reject the
 	// command.
 	if !needsRelocation && nTokens > 0 {
-		return fmt.Errorf("%s doesn't need tokens but %d token(s) were given",
+		return nil, fmt.Errorf("%s doesn't need tokens but %d token(s) were given",
 			hyper.HyperName, nTokens)
 
 	}
 
-	return nil
+	return session, nil
 }
 
-func (vm *vm) SendMessage(hyper *api.Hyper) error {
-	if err := vm.relocateHyperCommand(hyper); err != nil {
+func (vm *vm) SendMessage(hyper *api.Hyper) (err error) {
+	var session *ioSession
+
+	if session, err = vm.relocateHyperCommand(hyper); err != nil {
 		return err
 	}
 
-	_, err := vm.hyperHandler.SendCtlMessage(hyper.HyperName, hyper.Data)
+	_, err = vm.hyperHandler.SendCtlMessage(hyper.HyperName, hyper.Data)
+
+	if session != nil {
+		// We have now started the process inside the VM, let the shim send stdin
+		// data and signals.
+		close(session.processStarted)
+	}
 	return err
 }
 
@@ -428,8 +457,33 @@ func (session *ioSession) WaitForShim() error {
 	case <-time.After(waitForShimTimeout):
 		msg := fmt.Sprintf("timeout waiting for shim with token %s", session.token)
 		session.vm.logIO.Error(msg)
+		// No need to call session.ResetShim() here. We time out because we haven't
+		// seen a shim. This error will be reported to the runtime.
 		return errors.New(msg)
 	}
+
+	return nil
+}
+
+var waitForProcessTimeout = 30 * time.Second
+
+// WaitForProcess will wait until the process inside the VM is fully started. If
+// it's already the case, WaitForProcess will return immediately.
+func (session *ioSession) WaitForProcess() error {
+	session.vm.logIO.Infof("waiting for runtime to execute the process for token %s (timeout %s)",
+		session.token, waitForProcessTimeout)
+
+	select {
+	case <-session.processStarted:
+	case <-time.After(waitForProcessTimeout):
+		msg := fmt.Sprintf("timeout waiting for process with token %s", session.token)
+		session.vm.logIO.Error(msg)
+		// Runtime failed to do a newcontainer or execcmd. This error will cause us
+		// to close the connection to the sim.
+		session.ResetShim()
+		return errors.New(msg)
+	}
+
 	return nil
 }
 
@@ -442,6 +496,10 @@ func (session *ioSession) ForwardStdin(frame *api.Frame) error {
 	streamType := api.Stream(frame.Header.Opcode)
 	if streamType != api.StreamStdin {
 		return fmt.Errorf("expected stdin stream frame got %s", streamType)
+	}
+
+	if err := session.WaitForProcess(); err != nil {
+		return err
 	}
 
 	vm := session.vm
@@ -515,11 +573,12 @@ func (vm *vm) AllocateToken() (Token, error) {
 	}
 
 	session := &ioSession{
-		vm:            vm,
-		token:         token,
-		nStreams:      nStreams,
-		ioBase:        ioBase,
-		shimConnected: make(chan interface{}),
+		vm:             vm,
+		token:          token,
+		nStreams:       nStreams,
+		ioBase:         ioBase,
+		shimConnected:  make(chan interface{}),
+		processStarted: make(chan interface{}),
 	}
 
 	// This mapping is to get the session from the seq number in an

--- a/vm_test.go
+++ b/vm_test.go
@@ -130,7 +130,7 @@ func TestHyperRelocationNewcontainer(t *testing.T) {
 	// associate a dummy shim
 	vm.AssociateShim(Token(token), 1, nil)
 	// relocate
-	err := vm.relocateHyperCommand(cmd)
+	_, err := vm.relocateHyperCommand(cmd)
 	assert.Nil(t, err)
 
 	// Check that the relocated command contains the seq numbers
@@ -144,7 +144,7 @@ func TestHyperRelocationNewcontainer(t *testing.T) {
 
 	// Giving more than 1 token should result in an error
 	cmd = rig.createExecmd(vm, 2)
-	err = vm.relocateHyperCommand(cmd)
+	_, err = vm.relocateHyperCommand(cmd)
 	assert.NotNil(t, err)
 
 	rig.Stop()
@@ -168,7 +168,7 @@ func TestHyperRelocationNewcontainerNoToken(t *testing.T) {
 	// given.
 
 	// relocate
-	err := vm.relocateHyperCommand(cmd)
+	_, err := vm.relocateHyperCommand(cmd)
 	assert.Nil(t, err)
 
 	// Check that the relocated command contains the seq numbers
@@ -209,7 +209,7 @@ func TestHyperRelocationExeccmd(t *testing.T) {
 	// associate a dummy shim
 	vm.AssociateShim(Token(token), 1, nil)
 	// relocate
-	err := vm.relocateHyperCommand(cmd)
+	_, err := vm.relocateHyperCommand(cmd)
 	assert.Nil(t, err)
 
 	// Check that the relocated command contains the seq numbers
@@ -223,7 +223,7 @@ func TestHyperRelocationExeccmd(t *testing.T) {
 
 	// Giving more than 1 token should result in an error
 	cmd = rig.createExecmd(vm, 2)
-	err = vm.relocateHyperCommand(cmd)
+	_, err = vm.relocateHyperCommand(cmd)
 	assert.NotNil(t, err)
 
 	rig.Stop()
@@ -243,7 +243,7 @@ func TestHyperRelocationPing(t *testing.T) {
 	// 1 process can be spawned using execcmd.
 	cmd := rig.createHyperCmd(vm, "ping", 1, nil)
 	originalCmd := *cmd
-	err := vm.relocateHyperCommand(cmd)
+	_, err := vm.relocateHyperCommand(cmd)
 	assert.NotNil(t, err)
 	assert.Equal(t, originalCmd, *cmd)
 


### PR DESCRIPTION
A somewhat long-winded PR that should remove the need to start the shim as stopped. We finish the work to started to synchronise runtime, shim and the process inside the VM without queuing data. It can be a bit fiddly so the code is somewhat heavily documented and tested.