### PR TITLE
Prevent race condition with the per-client ID

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -528,9 +528,16 @@ func (proxy *proxy) init() error {
 	return nil
 }
 
-var nextClientID = uint64(1)
+var nextClientID = uint64(0)
 
 func (proxy *proxy) serveNewClient(proto *protocol, newConn net.Conn) {
+	// Unfortunately it's hard to find out information on the peer
+	// at the other end of a unix socket. We use a per-client ID to
+	// identify connections.  This ID needs to be unique.  To ensure
+	// this, the ID is first incremented and then assigned to prevent
+	// two peers from having the same ID.
+	atomic.AddUint64(&nextClientID, 1)
+
 	newClient := &client{
 		id:    nextClientID,
 		proxy: proxy,
@@ -538,11 +545,6 @@ func (proxy *proxy) serveNewClient(proto *protocol, newConn net.Conn) {
 		kind:  clientKindRuntime,
 	}
 
-	atomic.AddUint64(&nextClientID, 1)
-
-	// Unfortunately it's hard to find out information on the peer
-	// at the other end of a unix socket. We use a per-client ID to
-	// identify connections.
 	newClient.info(1, "client connected")
 
 	if err := proto.Serve(newConn, newClient); err != nil && err != io.EOF {


### PR DESCRIPTION
Because this ID needs to be unique per client, incrementing it before
assigning it.  Otherwise, if two requests are serviced at the same
time, there is a potential for both peers to have the same ID.  Can
also initialize the per-client ID to 0 instead of 1 before servicing
requests.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>