### PR TITLE
ci: Make the installation of linters verbose

### DIFF
--- a/.ci/go-lint.sh
+++ b/.ci/go-lint.sh
@@ -7,7 +7,7 @@ set -o pipefail
 if [ ! $(command -v gometalinter) ]
 then
 	go get github.com/alecthomas/gometalinter
-	gometalinter --install --vendor
+	gometalinter --install --vendor --debug
 fi
 
 gometalinter \


### PR DESCRIPTION
This can take some time and travis times out because it hasn't received
any message on stdout/stderr for 10 minutes.

There are a couple of ways to solve that, making the installation for
verbose may alleviate the problem a bit.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>