### PR TITLE
OWNERS: Add 2 more approvers

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -35,3 +35,5 @@ groups:
     users:
       - amshinde
       - dlespiau
+      - mcastelino
+      - sameo

--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,5 @@ reviewers:
 approvers:
 - amshinde
 - dlespiau
+- mcastelino
+- sameo


### PR DESCRIPTION
To prevent PRs from being blocked as PR pushers are also usually PR
approvers.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>