### PR TITLE
Add support for clients to send log entries to the proxy

### DIFF
--- a/.ci/go-lint.sh
+++ b/.ci/go-lint.sh
@@ -14,6 +14,8 @@ gometalinter \
 	--exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
 	--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
 	--exclude='duplicate of.*_test.go.*\(dupl\)$' \
+	--exclude='client.go:.*level can be fmt.Stringer' \
+	--exclude='client.go:.*source can be fmt.Stringer' \
 	--disable=aligncheck \
 	--disable=gotype \
 	--disable=gas \

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1,8 +1,8 @@
-memo = "a7ed328dcfd5b65a8cd7568c7dfcb150b37fdb3d4b0924bb4f5de4e51c09cd5b"
+memo = "1deea5082a90ba9354cb673741e7fe51536ec1e85cd5653a96bf07da354c8647"
 
 [[projects]]
   name = "github.com/Sirupsen/logrus"
-  packages = ["."]
+  packages = [".","hooks/test"]
   revision = "ba1b36c82c5e05c4f912a88eab0dcd91a171688f"
   version = "v0.11.5"
 

--- a/api/frame.go
+++ b/api/frame.go
@@ -30,6 +30,8 @@ import (
 //
 //       • Changed the frame header to include additional fields: version,
 //         header length, type and opcode.
+//       • Added a log messages for clients to insert log entries to the
+//         consolidated proxy log.
 //
 //   • version 1: initial version released with Clear Containers 2.1
 const Version = 2
@@ -129,6 +131,11 @@ const (
 	StreamStdout
 	// StreamStderr is a stream conveying stderr data.
 	StreamStderr
+	// StreamLog is a stream conveying structured logs messages. Each Log frame
+	// contains a JSON object which fields are the structured log. By convention
+	// it would be nice to have a few common fields in log entries to ease
+	// post-processing. See the LogEntry payload for details.
+	StreamLog
 	// StreamMax is the number of stream types.
 	StreamMax
 )
@@ -142,6 +149,8 @@ func (s Stream) String() string {
 		return "stdout"
 	case StreamStderr:
 		return "stderr"
+	case StreamLog:
+		return "log"
 	default:
 		return unknown
 	}

--- a/api/frame_test.go
+++ b/api/frame_test.go
@@ -65,6 +65,7 @@ func TestStreamString(t *testing.T) {
 		{StreamStdin, "stdin"},
 		{StreamStdout, "stdout"},
 		{StreamStderr, "stderr"},
+		{StreamLog, "log"},
 		{StreamMax, "unknown"},
 	}
 

--- a/api/payload.go
+++ b/api/payload.go
@@ -168,3 +168,16 @@ type Signal struct {
 type ErrorResponse struct {
 	Message string `json:"msg"`
 }
+
+// LogEntry is the payload for the StreamLog data.
+type LogEntry struct {
+	// Source is the source of the log entry. One of "shim" or "runtime".
+	Source string `json:"source"`
+	// ContainerID is the ID of the container the log entry is for (optional).
+	ContainerID string `json:"containerId,omitempty"`
+	// Level is the verbosity level of the log entry. One of "debug", "info", "warn"
+	// or "error".
+	Level string `json:"level"`
+	// Message is the log message
+	Message string `json:"msg"`
+}

--- a/client/client.go
+++ b/client/client.go
@@ -310,3 +310,79 @@ func (client *Client) sendStream(op api.Stream, data []byte) error {
 func (client *Client) SendStdin(data []byte) error {
 	return client.sendStream(api.StreamStdin, data)
 }
+
+// LogLevel is the severity of log entries.
+type LogLevel uint8
+
+const (
+	// LogLevelDebug is for log messages only useful debugging.
+	LogLevelDebug LogLevel = iota
+	// LogLevelInfo is for reporting landmark events.
+	LogLevelInfo
+	// LogLevelWarn is for reporting warnings.
+	LogLevelWarn
+	// LogLevelError is for reporting errors.
+	LogLevelError
+
+	logLevelMax
+)
+
+var levelToString = []string{"debug", "info", "warn", "error"}
+
+// String implements stringer for LogLevel.
+func (l LogLevel) String() string {
+	if l < logLevelMax {
+		return levelToString[l]
+	}
+
+	return "unknown"
+}
+
+// LogSource is the source of log entries
+type LogSource uint8
+
+const (
+	// LogSourceRuntime represents a runtime.
+	LogSourceRuntime LogSource = iota
+	// LogSourceShim represents a shim.
+	LogSourceShim
+
+	logSourceMax
+)
+
+var sourceToString = []string{"runtime", "shim"}
+
+// String implements stringer for LogSource
+func (s LogSource) String() string {
+	if s < logSourceMax {
+		return sourceToString[s]
+	}
+
+	return "unknown"
+}
+
+// Log sends log entries.
+func (client *Client) Log(level LogLevel, source LogSource, containerID string, args ...interface{}) {
+	payload := api.LogEntry{
+		Level:       level.String(),
+		Source:      source.String(),
+		ContainerID: containerID,
+		Message:     fmt.Sprint(args...),
+	}
+
+	data, _ := json.Marshal(&payload)
+	_ = client.sendStream(api.StreamLog, data)
+}
+
+// Logf sends log entries.
+func (client *Client) Logf(level LogLevel, source LogSource, containerID string, format string, args ...interface{}) {
+	payload := api.LogEntry{
+		Level:       level.String(),
+		Source:      source.String(),
+		ContainerID: containerID,
+		Message:     fmt.Sprintf(format, args...),
+	}
+
+	data, _ := json.Marshal(&payload)
+	_ = client.sendStream(api.StreamLog, data)
+}

--- a/proxy.go
+++ b/proxy.go
@@ -569,7 +569,7 @@ func (proxy *proxy) serve() {
 	proto.HandleCommand(api.CmdConnectShim, connectShim)
 	proto.HandleCommand(api.CmdDisconnectShim, disconnectShim)
 	proto.HandleCommand(api.CmdSignal, signal)
-	proto.HandleStream(forwardStdin)
+	proto.HandleStream(api.StreamStdin, forwardStdin)
 
 	logrus.Info("proxy started")
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -62,7 +62,7 @@ func newTestRig(t *testing.T) *testRig {
 	proto.HandleCommand(api.CmdConnectShim, connectShim)
 	proto.HandleCommand(api.CmdDisconnectShim, disconnectShim)
 	proto.HandleCommand(api.CmdSignal, signal)
-	proto.HandleStream(forwardStdin)
+	proto.HandleStream(api.StreamStdin, forwardStdin)
 
 	return &testRig{
 		t:        t,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -20,16 +20,15 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/clearcontainers/proxy/api"
 	goapi "github.com/clearcontainers/proxy/client"
+	"github.com/containers/virtcontainers/pkg/hyperstart"
 	"github.com/containers/virtcontainers/pkg/hyperstart/mock"
 
-	"syscall"
-
-	"github.com/containers/virtcontainers/pkg/hyperstart"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -99,7 +99,7 @@ func (rig *testRig) Start() {
 
 	// Client object that can be used to issue proxy commands
 	clientConn := rig.ServeNewClient()
-	rig.Client = goapi.NewClient(clientConn.(*net.UnixConn))
+	rig.Client = goapi.NewClient(clientConn)
 }
 
 func (rig *testRig) Stop() {

--- a/vendor/github.com/Sirupsen/logrus/hooks/test/test.go
+++ b/vendor/github.com/Sirupsen/logrus/hooks/test/test.go
@@ -1,0 +1,67 @@
+package test
+
+import (
+	"io/ioutil"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// test.Hook is a hook designed for dealing with logs in test scenarios.
+type Hook struct {
+	Entries []*logrus.Entry
+}
+
+// Installs a test hook for the global logger.
+func NewGlobal() *Hook {
+
+	hook := new(Hook)
+	logrus.AddHook(hook)
+
+	return hook
+
+}
+
+// Installs a test hook for a given local logger.
+func NewLocal(logger *logrus.Logger) *Hook {
+
+	hook := new(Hook)
+	logger.Hooks.Add(hook)
+
+	return hook
+
+}
+
+// Creates a discarding logger and installs the test hook.
+func NewNullLogger() (*logrus.Logger, *Hook) {
+
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	return logger, NewLocal(logger)
+
+}
+
+func (t *Hook) Fire(e *logrus.Entry) error {
+	t.Entries = append(t.Entries, e)
+	return nil
+}
+
+func (t *Hook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// LastEntry returns the last entry that was logged or nil.
+func (t *Hook) LastEntry() (l *logrus.Entry) {
+
+	if i := len(t.Entries) - 1; i < 0 {
+		return nil
+	} else {
+		return t.Entries[i]
+	}
+
+}
+
+// Reset removes all Entries from this test hook.
+func (t *Hook) Reset() {
+	t.Entries = make([]*logrus.Entry, 0)
+}

--- a/vendor/github.com/Sirupsen/logrus/hooks/test/test_test.go
+++ b/vendor/github.com/Sirupsen/logrus/hooks/test/test_test.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllHooks(t *testing.T) {
+
+	assert := assert.New(t)
+
+	logger, hook := NewNullLogger()
+	assert.Nil(hook.LastEntry())
+	assert.Equal(0, len(hook.Entries))
+
+	logger.Error("Hello error")
+	assert.Equal(logrus.ErrorLevel, hook.LastEntry().Level)
+	assert.Equal("Hello error", hook.LastEntry().Message)
+	assert.Equal(1, len(hook.Entries))
+
+	logger.Warn("Hello warning")
+	assert.Equal(logrus.WarnLevel, hook.LastEntry().Level)
+	assert.Equal("Hello warning", hook.LastEntry().Message)
+	assert.Equal(2, len(hook.Entries))
+
+	hook.Reset()
+	assert.Nil(hook.LastEntry())
+	assert.Equal(0, len(hook.Entries))
+
+	hook = NewGlobal()
+
+	logrus.Error("Hello error")
+	assert.Equal(logrus.ErrorLevel, hook.LastEntry().Level)
+	assert.Equal("Hello error", hook.LastEntry().Message)
+	assert.Equal(1, len(hook.Entries))
+
+}

--- a/vm.go
+++ b/vm.go
@@ -167,7 +167,7 @@ func (vm *vm) dump(data []byte) {
 	if logrus.GetLevel() != logrus.DebugLevel {
 		return
 	}
-	logrus.WithField("wm", vm.containerID).Debug("\n%s", hex.Dump(data))
+	logrus.WithField("wm", vm.containerID).Debug("\n", hex.Dump(data))
 }
 
 func (vm *vm) findSessionBySeq(seq uint64) *ioSession {

--- a/vm.go
+++ b/vm.go
@@ -493,15 +493,6 @@ func (session *ioSession) WaitForProcess(shouldReset bool) error {
 
 // ForwardStdin forwards an api.Frame with stdin data to hyperstart
 func (session *ioSession) ForwardStdin(frame *api.Frame) error {
-	if frame.Header.Type != api.TypeStream {
-		return fmt.Errorf("expected stream frame got %s", frame.Header.Type)
-	}
-
-	streamType := api.Stream(frame.Header.Opcode)
-	if streamType != api.StreamStdin {
-		return fmt.Errorf("expected stdin stream frame got %s", streamType)
-	}
-
 	if err := session.WaitForProcess(true); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds a new log stream type. Clients can use it to send structured log entries with a few predefined fields to the proxy.