### PR TITLE
Include coverage data of the 'client' package when running the main tests

### DIFF
--- a/.ci/go-lint.sh
+++ b/.ci/go-lint.sh
@@ -16,6 +16,7 @@ gometalinter \
 	--exclude='duplicate of.*_test.go.*\(dupl\)$' \
 	--exclude='client.go:.*level can be fmt.Stringer' \
 	--exclude='client.go:.*source can be fmt.Stringer' \
+	--exclude='error: no formatting directive in Logf call \(vet\)$' \
 	--disable=aligncheck \
 	--disable=gotype \
 	--disable=gas \

--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -17,7 +17,7 @@ function test_html_coverage
 
 function test_coverage
 {
-	echo "mode: count" > profile.cov
+	echo "mode: atomic" > profile.cov
 
 	for pkg in $test_packages; do
 		go test $go_test_flags -covermode=atomic -coverprofile=profile_tmp.cov $pkg

--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -3,7 +3,7 @@
 script_dir=$(cd `dirname $0`; pwd)
 root_dir=`dirname $script_dir`
 
-test_packages=". ./api"
+test_packages=('.;.,./client' './api;./api')
 go_test_flags="-v -race -timeout 2s"
 
 echo Running go test on packages "'$test_packages'" with flags "'$go_test_flags'"
@@ -19,8 +19,11 @@ function test_coverage
 {
 	echo "mode: atomic" > profile.cov
 
-	for pkg in $test_packages; do
-		go test $go_test_flags -covermode=atomic -coverprofile=profile_tmp.cov $pkg
+	for pkg in ${test_packages[@]}; do
+		fields=(${pkg//;/ })
+		pkg_name=${fields[0]}
+		pkg_cover=${fields[1]}
+		go test $go_test_flags -covermode=atomic -coverprofile=profile_tmp.cov -coverpkg $pkg_cover $pkg_name
 		[ -f profile_tmp.cov ] && tail -n +2 profile_tmp.cov >> profile.cov;
 		rm -f profile_tmp.cov
 	done

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -813,6 +813,8 @@ func TestLog(t *testing.T) {
 	entry := hook.LastEntry()
 	assert.NotNil(t, entry)
 	assert.Equal(t, logrus.WarnLevel, entry.Level)
+	assert.Equal(t, "shim", entry.Data["source"])
+	assert.Equal(t, testContainerID, entry.Data["container"])
 	assert.Equal(t, warningMessage, entry.Message)
 
 	rig.Stop()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -804,6 +804,7 @@ func TestLog(t *testing.T) {
 	rig.SetRunHyperstart(false)
 	rig.Start()
 
+	// Test Log()
 	const warningMessage = "A warning!"
 	hook := test.NewGlobal()
 	rig.Client.Log(goapi.LogLevelWarn, goapi.LogSourceShim, testContainerID, warningMessage)
@@ -816,6 +817,17 @@ func TestLog(t *testing.T) {
 	assert.Equal(t, "shim", entry.Data["source"])
 	assert.Equal(t, testContainerID, entry.Data["container"])
 	assert.Equal(t, warningMessage, entry.Message)
+
+	// Test Logf()
+	rig.Client.Logf(goapi.LogLevelError, goapi.LogSourceRuntime, testContainerID, "foo %s", "bar")
+
+	SyncWithProxy(rig.Client)
+
+	entry = hook.LastEntry()
+	assert.NotNil(t, entry)
+	assert.Equal(t, logrus.ErrorLevel, entry.Level)
+	assert.Equal(t, "runtime", entry.Data["source"])
+	assert.Equal(t, "foo bar", entry.Message)
 
 	rig.Stop()
 }


### PR DESCRIPTION
    ci: Include coverage data of the 'client' package in the main tests
    
    The main tests make heavy usage of the client package. The -coverpkg
    option allows to include more package than only the package currently
    tested in the coverage data.
    
    Including the client package shows we indeed cover quite a bit of it
    (80%) from the main tests.
