### PR TITLE
vm: Assign a container ID to each session

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -564,6 +564,8 @@ func TestShimSignal(t *testing.T) {
 	shim := rig.ServeNewShim(token)
 	session := peekIOSession(rig.proxy, token)
 
+	session.containerID = testContainerID
+
 	// Simulate that a runtime has started the VM process
 	close(session.processStarted)
 
@@ -675,7 +677,7 @@ func TestShimSendSignalAfterExeccmd(t *testing.T) {
 	go func() {
 		time.Sleep(smallWaitTimeout)
 		err := shim.client.Kill(syscall.SIGUSR1)
-		assert.Nil(t, err)
+		assert.NotNil(t, err)
 		wg.Done()
 	}()
 
@@ -690,10 +692,10 @@ func TestShimSendSignalAfterExeccmd(t *testing.T) {
 
 	wg.Wait()
 
-	// This time the signal cmd has been forwarded. Hyperstart should have
-	// received two messages (execcmd + signal)
+	// This time (again) the signal cmd has not been forwarded. Hyperstart
+	// should have received one messages (execcmd)
 	msgs = rig.Hyperstart.GetLastMessages()
-	assert.Equal(t, 2, len(msgs))
+	assert.Equal(t, 1, len(msgs))
 
 	// Cleanup
 	shim.close()


### PR DESCRIPTION
In case the shim receives a signal, it sends it to the proxy and the proxy has to figure out which container is affected by this signal. The current implementation provides the VM ID (called also pod ID), but this is not right in case we have the pod ID different from the container ID, or in case several containers are running on the same pod.

This patch creates a new field containerID in the Session structure so that we can fill this container ID when the command newcontainer is issued and actually use this information when a signal has to be issued.