### PR TITLE
pullapprove: Don't require doc team sign-off for vendor docs.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -41,7 +41,10 @@ groups:
   documentation:
     conditions:
       files:
-        - "*.md"
+        include:
+          - "*.md"
+        exclude:
+          - "vendor/*"
     required: 1
     teams:
       - documentation


### PR DESCRIPTION
Change the pullapprove config to ignore vendored documentation files.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>