### PR TITLE
proxy: Lift the numbers of opened file descriptors limit

### DIFF
--- a/cc-proxy.service.in
+++ b/cc-proxy.service.in
@@ -4,6 +4,7 @@ Documentation=https://github.com/clearcontainers/proxy
 
 [Service]
 ExecStart=@libexecdir@/clear-containers/cc-proxy
+LimitNOFILE=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We were hitting this limit before hitting memory limits in our density
test. Remove it. Linux stiff has a global limit that will apply, of
course.

Fixes: https://github.com/01org/cc-oci-runtime/issues/1008
Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>