### PR TITLE
Forward hyperstart response to clients

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -202,14 +202,14 @@ func (client *Client) AttachVM(containerID string, options *AttachVMOptions) (*A
 }
 
 // Hyper wraps the Hyper payload (see payload description for more details)
-func (client *Client) Hyper(hyperName string, hyperMessage interface{}) error {
+func (client *Client) Hyper(hyperName string, hyperMessage interface{}) ([]byte, error) {
 	return client.HyperWithTokens(hyperName, nil, hyperMessage)
 }
 
 // HyperWithTokens is a Hyper variant where the users can specify a list of I/O tokens.
 //
 // See the api.Hyper payload description for more details.
-func (client *Client) HyperWithTokens(hyperName string, tokens []string, hyperMessage interface{}) error {
+func (client *Client) HyperWithTokens(hyperName string, tokens []string, hyperMessage interface{}) ([]byte, error) {
 	var data []byte
 
 	if hyperMessage != nil {
@@ -217,7 +217,7 @@ func (client *Client) HyperWithTokens(hyperName string, tokens []string, hyperMe
 
 		data, err = json.Marshal(hyperMessage)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -232,10 +232,14 @@ func (client *Client) HyperWithTokens(hyperName string, tokens []string, hyperMe
 
 	resp, err := client.sendCommand(api.CmdHyper, &hyper)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return errorFromResponse(resp)
+	if err = errorFromResponse(resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Payload, errorFromResponse(resp)
 }
 
 // UnregisterVM wraps the api.UnregisterVM payload.

--- a/protocol.go
+++ b/protocol.go
@@ -28,6 +28,7 @@ type commandHandler func([]byte, interface{}, *handlerResponse)
 type handlerResponse struct {
 	err     error
 	results map[string]interface{}
+	data    []byte
 }
 
 func (r *handlerResponse) SetError(err error) {
@@ -47,6 +48,13 @@ func (r *handlerResponse) AddResult(key string, value interface{}) {
 		r.results = make(map[string]interface{})
 	}
 	r.results[key] = value
+}
+
+// SetData sets the data to be sent as the response payload. If both AddResult
+// and SetData are called on the same handlerResponse, SetData takes precedence
+// and defines what we be returned to the caller.
+func (r *handlerResponse) SetData(data []byte) {
+	r.data = data
 }
 
 // streamHandler is the prototype of function that can be registered to be
@@ -114,14 +122,25 @@ func (proto *protocol) handleCommand(ctx *clientCtx, cmd *api.Frame) *api.Frame 
 		return newErrorResponse(cmd.Header.Opcode, hr.err.Error())
 	}
 
-	var payload interface{}
-	if len(hr.results) > 0 {
-		payload = hr.results
+	var frame *api.Frame
+
+	if len(hr.data) > 0 {
+		// We have a full payload defined.
+		frame = api.NewFrame(api.TypeResponse, cmd.Header.Opcode, hr.data)
+	} else {
+		// Otherwise, we'll marshal hr.results, if we have any.
+		var payload interface{}
+		var err error
+
+		if len(hr.results) > 0 {
+			payload = hr.results
+		}
+		frame, err = api.NewFrameJSON(api.TypeResponse, cmd.Header.Opcode, payload)
+		if err != nil {
+			return newErrorResponse(cmd.Header.Opcode, err.Error())
+		}
 	}
-	frame, err := api.NewFrameJSON(api.TypeResponse, cmd.Header.Opcode, payload)
-	if err != nil {
-		return newErrorResponse(cmd.Header.Opcode, err.Error())
-	}
+
 	return frame
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -22,7 +22,6 @@ import (
 	"github.com/clearcontainers/proxy/api"
 )
 
-// XXX: could do with its own package to remove that ugly namespacing
 type commandHandler func([]byte, interface{}, *handlerResponse)
 
 // Encapsulates the different parts of what a handler can return.

--- a/proxy.go
+++ b/proxy.go
@@ -339,7 +339,8 @@ func hyper(data []byte, userData interface{}, response *handlerResponse) {
 
 	client.log.Infof("hyper(cmd=%s, data=%s)", hyper.HyperName, hyper.Data)
 
-	err := vm.SendMessage(&hyper)
+	data, err := vm.SendMessage(&hyper)
+	response.SetData(data)
 	response.SetError(err)
 }
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -833,3 +833,24 @@ func TestLog(t *testing.T) {
 
 	rig.Stop()
 }
+
+func TestHyperstartResponse(t *testing.T) {
+	rig := newTestRig(t)
+	rig.Start()
+
+	ctlSocketPath, ioSocketPath := rig.Hyperstart.GetSocketPaths()
+	_, err := rig.Client.RegisterVM(testContainerID, ctlSocketPath, ioSocketPath, nil)
+	assert.Nil(t, err)
+
+	// Pre-fill what hyper will return.
+	const testMsg = "Foo Foo!"
+	msgData := []byte(testMsg)
+	rig.Hyperstart.SendMessage(hyperstart.AckCode, msgData)
+
+	// Trigger and message + response.
+	data, err := rig.Client.Hyper("ping", msgData)
+	assert.Nil(t, err)
+	assert.Equal(t, msgData, data)
+
+	rig.Stop()
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -286,7 +286,7 @@ func TestHyperPing(t *testing.T) {
 	// Send ping and verify we have indeed received the message on the
 	// hyperstart side. Ping is somewhat interesting because it's a case of
 	// an hyper message without data.
-	err = rig.Client.Hyper("ping", nil)
+	_, err = rig.Client.Hyper("ping", nil)
 	assert.Nil(t, err)
 
 	msgs := rig.Hyperstart.GetLastMessages()
@@ -315,7 +315,7 @@ func TestHyperStartpod(t *testing.T) {
 		Hostname: "testhostname",
 		ShareDir: "rootfs",
 	}
-	err = rig.Client.Hyper("startpod", &startpod)
+	_, err = rig.Client.Hyper("startpod", &startpod)
 	assert.Nil(t, err)
 
 	msgs := rig.Hyperstart.GetLastMessages()
@@ -425,7 +425,7 @@ func TestHyperSequenceNumberRelocation(t *testing.T) {
 			Args: []string{"/bin/sh"},
 		},
 	}
-	err := rig.Client.HyperWithTokens("newcontainer", []string{token}, &newcontainer)
+	_, err := rig.Client.HyperWithTokens("newcontainer", []string{token}, &newcontainer)
 	assert.Nil(t, err)
 
 	// Verify hyperstart has received the message with relocation
@@ -617,7 +617,7 @@ func TestShimConnectAfterExeccmd(t *testing.T) {
 			Args: []string{"/bin/sh"},
 		},
 	}
-	err := rig.Client.HyperWithTokens("execcmd", []string{token}, &execcmd)
+	_, err := rig.Client.HyperWithTokens("execcmd", []string{token}, &execcmd)
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "timeout"))
 	waitForShimTimeout = oldTimeout
@@ -635,7 +635,7 @@ func TestShimConnectAfterExeccmd(t *testing.T) {
 		wg.Done()
 	}()
 
-	err = rig.Client.HyperWithTokens("execcmd", []string{token}, &execcmd)
+	_, err = rig.Client.HyperWithTokens("execcmd", []string{token}, &execcmd)
 	assert.Nil(t, err)
 
 	wg.Wait()
@@ -687,7 +687,7 @@ func TestShimSendSignalAfterExeccmd(t *testing.T) {
 			Args: []string{"/bin/sh"},
 		},
 	}
-	err = rig.Client.HyperWithTokens("execcmd", []string{token}, &execcmd)
+	_, err = rig.Client.HyperWithTokens("execcmd", []string{token}, &execcmd)
 	assert.Nil(t, err)
 
 	wg.Wait()
@@ -752,7 +752,7 @@ func TestShimSendStdinAfterExeccmd(t *testing.T) {
 			Args: []string{"/bin/sh"},
 		},
 	}
-	err = rig.Client.HyperWithTokens("execcmd", []string{token}, &execcmd)
+	_, err = rig.Client.HyperWithTokens("execcmd", []string{token}, &execcmd)
 	assert.Nil(t, err)
 
 	wg.Wait()

--- a/vm.go
+++ b/vm.go
@@ -555,8 +555,8 @@ func (session *ioSession) SendSignal(signal syscall.Signal) error {
 	// FIXME: Change this when hyperstart will be capable of forwarding a
 	// signal to a process different from the initial container process.
 	if session.containerID == "" {
-		return fmt.Errorf("Could not send the signal %s: Sending" +
-			" a signal to a process different from the initial" +
+		return fmt.Errorf("Could not send the signal %s: Sending"+
+			" a signal to a process different from the initial"+
 			" container process is not supported",
 			signal.String())
 	}

--- a/vm.go
+++ b/vm.go
@@ -430,21 +430,22 @@ func (vm *vm) relocateHyperCommand(hyper *api.Hyper) (*ioSession, error) {
 	return session, nil
 }
 
-func (vm *vm) SendMessage(hyper *api.Hyper) (err error) {
+func (vm *vm) SendMessage(hyper *api.Hyper) ([]byte, error) {
 	var session *ioSession
+	var err error
 
 	if session, err = vm.relocateHyperCommand(hyper); err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = vm.hyperHandler.SendCtlMessage(hyper.HyperName, hyper.Data)
+	response, err := vm.hyperHandler.SendCtlMessage(hyper.HyperName, hyper.Data)
 
 	if session != nil {
 		// We have now started the process inside the VM, let the shim send stdin
 		// data and signals.
 		close(session.processStarted)
 	}
-	return err
+	return response.Message, err
 }
 
 var waitForShimTimeout = 30 * time.Second


### PR DESCRIPTION
Until now, hyperstart was never sending data along with the response to commands we cared about. Julio wants to add a ps message that will send some data back though, so let's support that.

We can probably do nice things in the new agent with this as well