### PR TITLE
vm: Check SendCtlMessage() return to avoid a segmentation fault

### DIFF
--- a/.ci/go-lint.sh
+++ b/.ci/go-lint.sh
@@ -18,6 +18,7 @@ gometalinter \
 	--exclude='client.go:.*source can be fmt.Stringer' \
 	--exclude='error: no formatting directive in Logf call \(vet\)$' \
 	--disable=aligncheck \
+	--disable=megacheck \
 	--disable=gotype \
 	--disable=gas \
 	--disable=vetshadow \

--- a/vm.go
+++ b/vm.go
@@ -439,6 +439,9 @@ func (vm *vm) SendMessage(hyper *api.Hyper) ([]byte, error) {
 	}
 
 	response, err := vm.hyperHandler.SendCtlMessage(hyper.HyperName, hyper.Data)
+	if err != nil {
+		return nil, err
+	}
 
 	if session != nil {
 		// We have now started the process inside the VM, let the shim send stdin


### PR DESCRIPTION
In case the call to SendCtlMessage() was returning an error, the
response object was nil, but it was used anyway.
This patch makes sure we are not using the response handler in
case we got an error.