### PR TITLE
build: Unbreak DefaultSocketPath.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,8 @@ all: cc-proxy $(UNIT_FILES)
 #
 
 cc-proxy: $(SOURCES) Makefile
-	$(QUIET_GOBUILD)go build -i -o $@ \
-		-ldflags "-X main.DefaultSocketPath=$(PROXY_SOCKET)" \
-		-ldflags "-X main.Version=$(VERSION)"
+	$(QUIET_GOBUILD)go build -i -o $@ -ldflags \
+		"-X main.DefaultSocketPath=$(PROXY_SOCKET) -X main.Version=$(VERSION)"
 
 #
 # Tests


### PR DESCRIPTION
PR #87 inadvertently broke the build setting the default socket path
variable. This appears to be due to a bug in "go build" whereby it
accepts any number of -ldflags "-X ..." options, but only actually
honours the last one. On PR #87 this meant that the Version variable
was set, whilst DefaultSocketPath was silently ignored and its value
defaulted to "".

Fixes #90.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>