### PR TITLE
CI: Add ci scripts that execute tests on SemaphoreCI

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will execute the Clear Containers Test Suite. 
+
+set -e
+
+# Current docker tests:
+# TODO: Move these docker commands to more formal tests in 
+# `clearcontainers/tests` repository. See issue: 
+# https://github.com/clearcontainers/tests/issues/59
+container_id=$(sudo docker create busybox /bin/sleep 60)
+sudo docker ps -a
+sudo docker start ${container_id}
+sudo docker ps -a
+sudo docker exec ${container_id} echo hello
+sudo docker ps -a
+
+# try to unpause a container that isn't paused a few times
+tmpfile=$(mktemp)
+for i in 1 2 3
+do
+	{ sudo docker unpause ${container_id} &>"$tmpfile"; ret=$?; } || true
+	[ $ret -eq 0 ] && { cat "$tmpfile"; exit 1; }
+done
+
+sudo docker pause ${container_id}
+sudo docker inspect ${container_id}|grep -qi "\"Paused\":.*true"
+
+# try to pause an already paused container a few times
+for i in 1 2 3
+do
+	{ sudo docker pause ${container_id} &>"$tmpfile"; ret=$?; } || true
+	[ $ret -eq 0 ] && { cat "$tmpfile"; exit 1; }
+done
+
+rm -f "$tmpfile"
+
+sudo docker unpause ${container_id}
+sudo docker inspect ${container_id}|grep -qi "\"Paused\":.*false"
+
+sudo docker ps -a
+sudo docker stop ${container_id}
+sudo docker ps -a
+sudo docker rm ${container_id}
+sudo docker ps -a
+
+# Execute the tests under `clearcontainers/tests` repository.
+test_repo="github.com/clearcontainers/tests"
+cd "${GOPATH}/src/${test_repo}"
+sudo -E PATH=$PATH make check

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -21,22 +21,30 @@
 
 set -e
 
+test_repo="github.com/clearcontainers/tests"
+
+# Clone Tests repository.
+go get "$test_repo"
+
+test_repo_dir="${GOPATH}/src/${test_repo}"
+
 if [ "$TRAVIS" = true ]
 then
-    test_repo="github.com/clearcontainers/tests"
+	# Check the commits in the branch
+	checkcommits_dir="${test_repo_dir}/cmd/checkcommits"
+	(cd "${checkcommits_dir}" && make)
+	checkcommits \
+		--need-fixes \
+		--need-sign-offs \
+		--body-length 72 \
+		--subject-length 75 \
+		--verbose
 
-    # Clone Tests repository.
-    go get "$test_repo"
-
-    test_repo_dir="${GOPATH}/src/${test_repo}"
-
-    # Check the commits in the branch
-    checkcommits_dir="${test_repo_dir}/cmd/checkcommits"
-    (cd "${checkcommits_dir}" && make)
-    checkcommits \
-        --need-fixes \
-        --need-sign-offs \
-        --body-length 72 \
-        --subject-length 75 \
-        --verbose
+	# Travis doesn't provide a VT-x environment, so nothing more to do
+	# here.
+	exit 0
 fi
+
+# Setup environment and build components.
+cd "${test_repo_dir}"
+sudo -E PATH=$PATH bash .ci/setup.sh

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will get any execution log that may be useful for
+# debugging any issue related to Clear Containers and clean the
+# test environment.
+
+sudo cat /var/lib/clear-containers/runtime/runtime.log
+sudo cat /var/log/upstart/cc-proxy.log
+sudo cat /var/log/upstart/crio.log


### PR DESCRIPTION
This commit adds the CI scripts that will execute the functional
and integration tests from the clearcontainers/tests repository.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>