### PR TITLE
proxy: Handle KILL and TERM signals when process not running

### DIFF
--- a/vm.go
+++ b/vm.go
@@ -518,6 +518,16 @@ func (session *ioSession) ForwardStdin(frame *api.Frame) error {
 	return vm.hyperHandler.SendIoMessage(msg)
 }
 
+// TerminateShim forces the shim to exit
+func (session *ioSession) TerminateShim() error {
+	exitCode := uint8(0)
+	frame := api.NewFrame(api.TypeNotification, int(api.NotificationProcessExited), []byte{exitCode})
+
+	session.vm.logIO.Infof("proxy terminating the shim")
+
+	return api.WriteFrame(session.client, frame)
+}
+
 // windowSizeMessage07 is the hyperstart 0.7 winsize message payload for the
 // winsize command. This payload has changed in 0.8 so we can't use the
 // definition in the hyperstart package.


### PR DESCRIPTION
Because a state transition from "ready" to "stopped" is possible
for a container created by virtcontainers/runtime, we can end up
with situations where the proxy waits for the shim process to start
so that it can forward a KILL or TERM signal, leading to a deadlock.
Instead, we want the proxy to be smarter, meaning terminate the shim
by himself. Indeed, there is no process/container running inside the
VM, meaning that the corresponding shim will never receive the exit
code from the VM unless the proxy takes care of this.

Fixes #97