### PR TITLE
build: Fix unit tests built using go tip

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const unixURLPrefix = "unix:"
+
 type testRig struct {
 	t  *testing.T
 	wg sync.WaitGroup
@@ -342,7 +344,7 @@ func TestRegisterVMAllocateTokens(t *testing.T) {
 		&goapi.RegisterVMOptions{NumIOStreams: 2})
 	assert.Nil(t, err)
 	assert.NotNil(t, ret)
-	assert.True(t, strings.HasPrefix(ret.IO.URL, "unix://"))
+	assert.True(t, strings.HasPrefix(ret.IO.URL, unixURLPrefix))
 	assert.Equal(t, 2, len(ret.IO.Tokens))
 
 	// This test shouldn't send anything to hyperstart.
@@ -365,7 +367,7 @@ func TestAttachVMAllocateTokens(t *testing.T) {
 	ret, err := rig.Client.AttachVM(testContainerID, &goapi.AttachVMOptions{NumIOStreams: 2})
 	assert.Nil(t, err)
 	assert.NotNil(t, ret)
-	assert.True(t, strings.HasPrefix(ret.IO.URL, "unix://"))
+	assert.True(t, strings.HasPrefix(ret.IO.URL, unixURLPrefix))
 	assert.Equal(t, 2, len(ret.IO.Tokens))
 
 	// Cleanup


### PR DESCRIPTION
Unit tests in go version devel +e3f3ade are failing
because URL does not match.

Fix match with the needed prefix given in e3f3ade .

Fixes: #115

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>