### PR TITLE
KSM tuning

### DIFF
--- a/docs/ksm.md
+++ b/docs/ksm.md
@@ -1,0 +1,129 @@
+# Kernel Same-Page tuning
+
+This section describes why `cc-proxy` tunes the host kernel
+Kernel Same-Page ([KSM](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/vm/ksm.txt))
+settings and how it does it.
+
+## What is KSM?
+
+KSM is a host Linux* kernel feature for de-duplicating memory pages.
+Although it was initially designed as a KVM specific feature, it is
+now part of the generic Linux memory management subsystem and can
+be leveraged by any userspace component or application looking for
+memory to save.
+
+A daemon (`ksmd`) periodically scans userspace memory, looking for
+identical pages that can be replaced by a single, write-protected
+page. When a process tries to modify this shared page content, it
+gets a private copy into its memory space. KSM only scans and merges
+pages that are both anonymous and that have been explictly tagged as
+mergeable by applications calling into the `madvise` system call
+(`int madvice(addr, length, MADV_MERGEABLE)`).
+
+KSM is customizable through a set of Linux kernel `sysfs` attributes,
+the most interesting ones being:
+
+  * `/sys/kernel/mm/ksm/run`: Turns KSM on (`1`) and off (`0`).
+  * `/sys/kernel/mm/ksm/sleep_millisec`: Knob that specifies the KSM
+    scanning period.
+  * `/sys/kernel/mm/ksm/pages_to_scan`: Sets the number of
+    pages KSM will scan per scanning cycle.
+
+The memory density improvements that KSM can provide come at a cost.
+Depending on the number of anonymous pages it will scan, it can be
+relatively expensive on CPU utilization.
+
+## `cc-proxy` and KSM
+
+The ideal KSM use case is when a given system runs a large amount
+of identical and relatively long running virtual machines (VMs).
+This is because when all the VMs run the same code, share the same
+data and start the same processes, they will be allocating a lot of
+identical pages that KSM can process and de-duplicate into shared
+single pages.
+
+A system running Intel® Clear Containers fits the above use case
+precisely. Using KSM appropriately in Clear Container sytems can
+significantly reduce memory footprint. This is why `cc-proxy` tries
+to optimally tune KSM.
+
+`cc-proxy` is the right component to tune KSM for the following reasons:
+
+  * KSM settings are system wide ones that should be controlled by
+    a system daemon like `cc-proxy`.
+  * `cc-proxy` is where you can optimize KSM settings based on
+     container creation activities.
+
+## Theory of operation
+
+`cc-proxy` supports three KSM modes, available through a command line
+option: `cc-proxy -ksm`.
+
+  1. `initial`: In this mode, `cc-proxy` does not take control of the
+     system KSM settings. It does not turn KSM on or off, and does not
+     modify any of the KSM settings.
+
+  2. `off`: When running with `-ksm off`, `cc-proxy` will completely
+     disable KSM on the system.
+
+  3. `throttle`: In `throttle` mode, `cc-proxy` will throttle KSM up
+     and down depending on the Clear Containers creation activity. This
+     is the `cc-proxy` default KSM mode.
+
+### KSM throttling
+
+By default, `cc-proxy` will throttle KSM up and down. Regardless of
+the current KSM system settings, `cc-proxy` will move them to the
+`aggressive` settings as soon as a new Clear Container is created.
+With the `aggressive` setting, ksmd will run every millisecond and
+will scan 10% of all available anonymous pages during each scanning
+cycle.
+
+After switching to the `aggressive` KSM settings, `cc-proxy` will
+throttle down to the `standard` setting if there are no additional
+Clear Containers instances created for 30 seconds.
+Then `cc-proxy` will continue throttling down to the `slow` KSM
+setting if there no further Clear Container creation for the next
+two minutes.
+Finally, `cc-proxy` will get back to the initial KSM settings after
+two more minutes, unless a new Clear Container is created.
+
+At any point in time, `cc-proxy` will get back to to the `aggressive`
+setting when detecting the creation of a Clear Container:
+
+```
+        +----------------+
+        |                |
+        |    Initial     |
+        |    Settings    |<<-------------------------------+
+        |                |                                 |
+        +-------+--------+                                 |
+                |                                          |
+        New     |                                          |
+     Container  |                                          |
+                |                                          |
+                v                                          |
+         +--------------+                                  |
+         |  Aggressive  |<<--------+                       |
+         +--------------+          |                       |
+                |                  |                       |
+  No Container  |                  |                       |
+     (30s)      |                  |    New                |
+                |                  |  Container            |    No Container
+                v                  |                       |       (2mn)
+         +--------------+          |                       |
+         |   Standard   |----------+                       |
+         +--------------+          |                       |
+                |                  |                       |
+  No Container  |                  |                       |
+     (2mn)      |                  |    New                |
+                |                  |  Container            |
+                v                  |                       |
+         +--------------+          |                       |
+         |     Slow     |----------+                       |
+         +--------------+                                  |
+                |                                          |
+                |                                          |
+                +------------------------------------------+
+
+```

--- a/ksm.go
+++ b/ksm.go
@@ -312,7 +312,7 @@ func startKSM(root string, mode ksmMode) (*ksm, error) {
 
 	// We just no-op if going for initial settings
 	if mode != ksmInitial {
-		// we want to catch termination to restore the initial sysfs values
+		// We want to catch termination to restore the initial sysfs values
 		c := make(chan os.Signal, 2)
 		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 

--- a/ksm.go
+++ b/ksm.go
@@ -83,6 +83,10 @@ func anonPages() (int64, error) {
 }
 
 func (s ksmSetting) pagesToScan() (string, error) {
+	if s.pagesPerScanFactor == 0 {
+		return "", errors.New("Invalid KSM setting")
+	}
+
 	nPages, err := anonPages()
 	if err != nil {
 		return "", err

--- a/ksm.go
+++ b/ksm.go
@@ -1,0 +1,276 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+)
+
+type ksmSetting struct {
+	// run describes if we want KSM to be on or off.
+	run bool
+
+	// pagesPerScanFactor describes how many pages we want
+	// to scan per KSM run.
+	// ksmd will san N pages, where N*pagesPerScanFactor is
+	// equal to the number of anonymous pages.
+	pagesPerScanFactor uint32
+
+	// scanIntervalMS is the KSM scan interval in milliseconds.
+	scanIntervalMS uint32
+}
+
+func (s ksmSetting) pagesToScan() (string, error) {
+	return "10000", nil
+}
+
+const (
+	ksmInitial    = "initial"
+	ksmOff        = "off"
+	ksmSlow       = "slow"
+	ksmStandard   = "standard"
+	ksmAggressive = "aggressive"
+)
+
+var ksmSettings = map[string]ksmSetting{
+	ksmOff:        {false, 1000, 500}, // Turn KSM off
+	ksmSlow:       {true, 500, 100},   // Every 100ms, we scan 1 page for every 500 pages available in the system
+	ksmStandard:   {true, 100, 10},    // Every 10ms, we scan 1 page for every 100 pages available in the system
+	ksmAggressive: {true, 10, 1},      // Every ms, we scan 1 page for every 10 pages available in the system
+}
+
+var defaultKSMRoot = "/sys/kernel/mm/ksm/"
+var errKSMUnavailable = errors.New("KSM is unavailable")
+
+const (
+	ksmRunFile        = "run"
+	ksmPagesToScan    = "pages_to_scan"
+	ksmSleepMillisec  = "sleep_millisecs"
+	ksmStart          = "1"
+	ksmStop           = "0"
+	defaultKSMSetting = ksmInitial
+)
+
+type sysfsAttribute struct {
+	path string
+	file *os.File
+}
+
+func (attr *sysfsAttribute) open() error {
+	file, err := os.OpenFile(attr.path, os.O_RDWR|syscall.O_NONBLOCK, 0660)
+	attr.file = file
+	return err
+}
+
+func (attr *sysfsAttribute) close() error {
+	err := attr.file.Close()
+	attr.file = nil
+	return err
+}
+
+func (attr *sysfsAttribute) read() (string, error) {
+	_, err := attr.file.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := ioutil.ReadAll(attr.file)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func (attr *sysfsAttribute) write(value string) error {
+	_, err := attr.file.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return err
+	}
+	_, err = attr.file.WriteString(value)
+
+	return err
+}
+
+type ksm struct {
+	root          string
+	run           sysfsAttribute
+	pagesToScan   sysfsAttribute
+	sleepInterval sysfsAttribute
+	initialized   bool
+
+	initialPagesToScan   string
+	initialSleepInterval string
+	initialKSMRun        string
+
+	sync.Mutex
+}
+
+func (k *ksm) isAvailable() error {
+	info, err := os.Stat(k.root)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("%s is not available", k.root)
+	}
+
+	return nil
+}
+
+func newKSM(root string) (*ksm, error) {
+	var err error
+	var k ksm
+
+	k.initialized = false
+	k.root = root
+
+	if root == "" {
+		return nil, errors.New("Invalid KSM root")
+	}
+
+	if err := k.isAvailable(); err != nil {
+		return nil, err
+	}
+
+	k.pagesToScan = sysfsAttribute{
+		path: filepath.Join(k.root, ksmPagesToScan),
+	}
+
+	k.sleepInterval = sysfsAttribute{
+		path: filepath.Join(k.root, ksmSleepMillisec),
+	}
+
+	k.run = sysfsAttribute{
+		path: filepath.Join(k.root, ksmRunFile),
+	}
+
+	defer func(err error) {
+		if err != nil {
+			_ = k.run.close()
+			_ = k.sleepInterval.close()
+			_ = k.pagesToScan.close()
+		}
+	}(err)
+
+	if err := k.run.open(); err != nil {
+		return nil, err
+	}
+
+	if err := k.sleepInterval.open(); err != nil {
+		return nil, err
+	}
+
+	if err := k.pagesToScan.open(); err != nil {
+		return nil, err
+	}
+
+	k.initialPagesToScan, err = k.pagesToScan.read()
+	if err != nil {
+		return nil, err
+	}
+
+	k.initialSleepInterval, err = k.sleepInterval.read()
+	if err != nil {
+		return nil, err
+	}
+
+	k.initialKSMRun, err = k.run.read()
+	if err != nil {
+		return nil, err
+	}
+
+	k.initialized = true
+	return &k, nil
+}
+
+func (k *ksm) restore() error {
+	var err error
+
+	k.Lock()
+	defer k.Unlock()
+
+	if !k.initialized {
+		return errKSMUnavailable
+	}
+
+	if err = k.pagesToScan.write(k.initialPagesToScan); err != nil {
+		return err
+	}
+
+	if err = k.sleepInterval.write(k.initialSleepInterval); err != nil {
+		return err
+	}
+
+	if err = k.run.write(k.initialKSMRun); err != nil {
+		return err
+	}
+
+	if err := k.run.close(); err != nil {
+		return err
+	}
+
+	if err := k.sleepInterval.close(); err != nil {
+		return err
+	}
+
+	if err := k.pagesToScan.close(); err != nil {
+		return err
+	}
+
+	k.initialized = false
+	return nil
+}
+
+func (k *ksm) tune(s ksmSetting) error {
+	k.Lock()
+	defer k.Unlock()
+
+	if !k.initialized {
+		return errKSMUnavailable
+	}
+
+	if !s.run {
+		return k.run.write(ksmStop)
+	}
+
+	newPagesToScan, err := s.pagesToScan()
+	if err != nil {
+		return err
+	}
+
+	if err = k.run.write(ksmStop); err != nil {
+		return err
+	}
+
+	if err = k.pagesToScan.write(newPagesToScan); err != nil {
+		return err
+	}
+
+	if err = k.sleepInterval.write(fmt.Sprintf("%v", s.scanIntervalMS)); err != nil {
+		return err
+	}
+
+	if err = k.run.write(ksmStart); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/ksm.go
+++ b/ksm.go
@@ -101,11 +101,11 @@ type ksmMode string
 
 const (
 	ksmInitial    ksmMode = "initial"
-	ksmOff                = "off"
-	ksmSlow               = "slow"
-	ksmStandard           = "standard"
-	ksmAggressive         = "aggressive"
-	ksmAuto               = "auto"
+	ksmOff        ksmMode = "off"
+	ksmSlow       ksmMode = "slow"
+	ksmStandard   ksmMode = "standard"
+	ksmAggressive ksmMode = "aggressive"
+	ksmAuto       ksmMode = "auto"
 )
 
 var ksmSettings = map[ksmMode]ksmSetting{

--- a/ksm.go
+++ b/ksm.go
@@ -196,6 +196,12 @@ func (attr *sysfsAttribute) write(value string) error {
 	if err != nil {
 		return err
 	}
+
+	err = attr.file.Truncate(0)
+	if err != nil {
+		return err
+	}
+
 	_, err = attr.file.WriteString(value)
 
 	return err

--- a/ksm_test.go
+++ b/ksm_test.go
@@ -298,6 +298,7 @@ func TestKSMKick(t *testing.T) {
 	k := initKSM(defaultKSMRoot, t)
 
 	timer := time.NewTimer(time.Second)
+	k.throttling = true
 	go k.kick()
 
 	select {

--- a/ksm_test.go
+++ b/ksm_test.go
@@ -1,0 +1,103 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ksmTestPrepare() error {
+	newKSMRoot, err := ioutil.TempDir("", "cc-ksm-test")
+	if err != nil {
+		return err
+	}
+
+	defaultKSMRoot = newKSMRoot
+
+	ksmTestRun, err := os.Create(filepath.Join(defaultKSMRoot, ksmRunFile))
+	if err != nil {
+		return err
+	}
+
+	ksmTestPagesToScan, err := os.Create(filepath.Join(defaultKSMRoot, ksmPagesToScan))
+	if err != nil {
+		return err
+	}
+
+	ksmTestSleepMillisec, err := os.Create(filepath.Join(defaultKSMRoot, ksmSleepMillisec))
+	if err != nil {
+		return err
+	}
+
+	defer ksmTestRun.Close()
+	defer ksmTestPagesToScan.Close()
+	defer ksmTestSleepMillisec.Close()
+
+	return nil
+}
+
+func ksmTestCleanup() {
+	os.RemoveAll(defaultKSMRoot)
+}
+
+func TestKSMSysfsAttributeOpen(t *testing.T) {
+	pagesToScanSysFs := sysfsAttribute{
+		path: filepath.Join(defaultKSMRoot, ksmPagesToScan),
+	}
+
+	err := pagesToScanSysFs.open()
+	defer pagesToScanSysFs.close()
+
+	assert.Nil(t, err)
+}
+
+func TestKSMSysfsAttributeOpenNonExistent(t *testing.T) {
+	pagesToScanSysFs := sysfsAttribute{
+		path: filepath.Join(defaultKSMRoot, "foo"),
+	}
+
+	err := pagesToScanSysFs.open()
+	defer pagesToScanSysFs.close()
+
+	assert.NotNil(t, err)
+}
+
+const ksmString = "ksmrules"
+
+func TestKSMSysfsAttributeReadWrite(t *testing.T) {
+	pagesToScanSysFs := sysfsAttribute{
+		path: filepath.Join(defaultKSMRoot, ksmPagesToScan),
+	}
+
+	err := pagesToScanSysFs.open()
+	defer pagesToScanSysFs.close()
+
+	assert.Nil(t, err)
+
+	err = pagesToScanSysFs.write(ksmString)
+	assert.Nil(t, err)
+
+	s, err := pagesToScanSysFs.read()
+	assert.Nil(t, err)
+	assert.NotNil(t, s)
+	assert.Equal(t, s, ksmString, "Wrong sysfs read: %s", s)
+}

--- a/ksm_test.go
+++ b/ksm_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -291,4 +292,19 @@ func TestKSMRestore(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 	assert.Equal(t, s, interval)
+}
+
+func TestKSMKick(t *testing.T) {
+	k := initKSM(defaultKSMRoot, t)
+
+	timer := time.NewTimer(time.Second)
+	go k.kick()
+
+	select {
+	case <-k.kickChannel:
+		return
+
+	case <-timer.C:
+		t.Fatalf("KSM kick timeout")
+	}
 }

--- a/ksm_test.go
+++ b/ksm_test.go
@@ -28,6 +28,9 @@ import (
 
 const ksmString = "ksmrules"
 const anonPagesMemory = 16777216 // Typically 4096 pages
+const run = "1"
+const interval = "10"
+const scan = "1000"
 
 func ksmTestPrepare() error {
 	newKSMRoot, err := ioutil.TempDir("", "cc-ksm-test")
@@ -165,4 +168,45 @@ func TestKSMPagesToScanInvalidSetting(t *testing.T) {
 
 	_, err := setting.pagesToScan()
 	assert.NotNil(t, err)
+}
+
+func TestKSMInit(t *testing.T) {
+	runSysFs := sysfsAttribute{
+		path: filepath.Join(defaultKSMRoot, ksmRunFile),
+	}
+
+	err := runSysFs.open()
+	defer runSysFs.close()
+	assert.Nil(t, err)
+
+	err = runSysFs.write(run)
+	assert.Nil(t, err)
+
+	pagesToScanSysFs := sysfsAttribute{
+		path: filepath.Join(defaultKSMRoot, ksmPagesToScan),
+	}
+
+	err = pagesToScanSysFs.open()
+	defer pagesToScanSysFs.close()
+	assert.Nil(t, err)
+
+	err = pagesToScanSysFs.write(scan)
+	assert.Nil(t, err)
+
+	sleepIntervalSysFs := sysfsAttribute{
+		path: filepath.Join(defaultKSMRoot, ksmSleepMillisec),
+	}
+
+	err = sleepIntervalSysFs.open()
+	defer sleepIntervalSysFs.close()
+	assert.Nil(t, err)
+
+	err = sleepIntervalSysFs.write(interval)
+	assert.Nil(t, err)
+
+	k := initKSM(defaultKSMRoot, t)
+
+	assert.Equal(t, k.initialPagesToScan, scan)
+	assert.Equal(t, k.initialSleepInterval, interval)
+	assert.Equal(t, k.initialKSMRun, run)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -31,5 +31,13 @@ func TestMain(m *testing.M) {
 		fmt.Fprint(os.Stderr, err)
 	}
 
-	os.Exit(m.Run())
+	if err := ksmTestPrepare(); err != nil {
+		fmt.Fprint(os.Stderr, err)
+	}
+
+	exit := m.Run()
+
+	ksmTestCleanup()
+
+	os.Exit(exit)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -32,6 +32,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := ksmTestPrepare(); err != nil {
+		ksmTestCleanup()
 		fmt.Fprint(os.Stderr, err)
 	}
 

--- a/proxy.go
+++ b/proxy.go
@@ -721,11 +721,11 @@ func proxyMain() {
 			os.Exit(0)
 		}()
 
-		if ksmKnob != ksmInitial {
-			if ksmKnob == ksmAuto {
+		if proxyKSMMode != ksmInitial {
+			if proxyKSMMode == ksmAuto {
 				proxyKSM.throttle()
 			} else {
-				if err := proxyKSM.tune(ksmSettings[ksmKnob]); err != nil {
+				if err := proxyKSM.tune(ksmSettings[proxyKSMMode]); err != nil {
 					fmt.Fprintln(os.Stderr, "init:", err.Error())
 				}
 			}
@@ -791,7 +791,7 @@ func (p *profiler) setup() {
 
 // Version is the proxy version. This variable is populated at build time.
 var Version = "unknown"
-var ksmKnob ksmSettingKnob
+var proxyKSMMode ksmMode
 
 func main() {
 	doVersion := flag.Bool("version", false, "display the version")
@@ -807,9 +807,9 @@ func main() {
 	flag.UintVar(&pprof.port, "pprof-port", 6060,
 		"port the pprof server will be bound to")
 
-	ksmKnob = defaultKSMSetting
+	proxyKSMMode = defaultKSMMode
 
-	flag.Var(&ksmKnob, "ksm", "KSM settings [off, initial, auto]")
+	flag.Var(&proxyKSMMode, "ksm", "KSM settings [off, initial, auto]")
 
 	flag.Parse()
 

--- a/proxy.go
+++ b/proxy.go
@@ -572,6 +572,9 @@ func newProxy() *proxy {
 //   ${locatestatedir}/run/cc-oci-runtime/proxy
 var DefaultSocketPath string
 
+// CC 2.1 socket path.
+var legacySocketPath = "/var/run/cc-oci-runtime/proxy.sock"
+
 // ArgSocketPath is populated at runtime from the option -socket-path
 var ArgSocketPath = flag.String("socket-path", "", "specify path to socket file")
 
@@ -583,7 +586,7 @@ func getSocketPath() (string, error) {
 	// populate DefaultSocketPath, so fallback to a reasonable
 	// path. People should really use the Makefile though.
 	if DefaultSocketPath == "" {
-		DefaultSocketPath = "/var/run/cc-oci-runtime/proxy.sock"
+		DefaultSocketPath = legacySocketPath
 	}
 
 	socketPath := DefaultSocketPath

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -65,7 +65,7 @@ func newTestRig(t *testing.T) *testRig {
 	proto.HandleCommand(api.CmdHyper, hyper)
 	proto.HandleCommand(api.CmdConnectShim, connectShim)
 	proto.HandleCommand(api.CmdDisconnectShim, disconnectShim)
-	proto.HandleCommand(api.CmdSignal, signal)
+	proto.HandleCommand(api.CmdSignal, cmdSignal)
 	proto.HandleStream(api.StreamStdin, forwardStdin)
 	proto.HandleStream(api.StreamLog, handleLogEntry)
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -902,3 +902,30 @@ func TestHyperstartResponse(t *testing.T) {
 
 	rig.Stop()
 }
+
+func TestGetSocketPath(t *testing.T) {
+	p, err := getSocketPath()
+	assert.Nil(t, err)
+	assert.Equal(t, p, legacySocketPath)
+
+	// Test for default socket path
+	DefaultSocketPath = "/proxy/socket/path"
+	p, err = getSocketPath()
+	assert.Nil(t, err, err)
+	assert.Equal(t, p, DefaultSocketPath)
+
+	// Test that a passed socket path takes precedence
+	var cliSocketPath = "/cli/proxy/socket/path"
+	ArgSocketPath = &cliSocketPath
+	p, err = getSocketPath()
+	assert.Nil(t, err, err)
+	assert.Equal(t, p, cliSocketPath)
+
+	// Test for too long socket paths
+	longPath := make([]byte, socketPathMaxLength+1)
+	cliSocketPath = string(longPath)
+	ArgSocketPath = &cliSocketPath
+	p, err = getSocketPath()
+	assert.NotNil(t, err, err)
+	assert.Equal(t, p, "")
+}


### PR DESCRIPTION
We set KSM settings (when available) from `cc-proxy`.
Our default setting is the aggressive one, as we're trying to share as much memory as possible. The default KSM setting knob can be selected from the `cc-proxy` command line (`cc-proxy -ksm`)
    
The initial KSM settings are restored when the proxy terminates.
