### PR TITLE
release: Clear Contianers 3.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # The version should be bumped and the '+' sign removed just before tagging a
 # new release.
 # A '+' sign should be added in the commit just after tagging a new release.
-VERSION := 3.0.1+
+VERSION := 3.0.2+
 
 DESTDIR :=
 PREFIX := /usr


### PR DESCRIPTION
Version bump for Clear Contianers 3.0.2

## Changes
- logging: Use nanosecond timestamps
- readme: Update build badges
- Make all log entries parseable

## Shortlog
b43cbce logging: Use nanosecond timestamps
db0cae7 readme: Update build badges
ac457b2 logging: Fix logging of hex messages
0975081 logging: Ensure correct quoting of message data

Fixes: #137

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>