### PR TITLE
init: coredump on internal error

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -617,6 +618,9 @@ func getSocketPath() (string, error) {
 func (proxy *proxy) init() error {
 	var l net.Listener
 	var err error
+
+	// Force a coredump + full stacktrace on internal error
+	debug.SetTraceback("crash")
 
 	// flags
 	proxy.enableVMConsole = logrus.GetLevel() == logrus.DebugLevel


### PR DESCRIPTION
Override the default golang panic handling by printing a full traceback
(not just for the current goroutine) and coredumping to allow
crash-handling programs like apport to log the details.

Fixes #141.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>