### PR TITLE
ksm: Fix deadlock

### DIFF
--- a/ksm.go
+++ b/ksm.go
@@ -530,17 +530,19 @@ func (k *ksm) throttle() {
 // kick gets us back to the aggressive setting
 func (k *ksm) kick() {
 	k.Lock()
-	defer k.Unlock()
 
 	if !k.initialized {
 		proxyLog.Error(errors.New("KSM is unavailable"))
+		k.Unlock()
 		return
 	}
 
 	// If we're not throttling, we must not kick.
 	if !k.throttling {
+		k.Unlock()
 		return
 	}
 
+	k.Unlock()
 	k.kickChannel <- true
 }


### PR DESCRIPTION
We need to release the lock before pushing data into the kick channel.
If we push while holding the lock and the throttle loop is waiting for
the KSM lock, we will deadlock.

Fixes #143

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>