### PR TITLE
release: 3.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # The version should be bumped and the '+' sign removed just before tagging a
 # new release.
 # A '+' sign should be added in the commit just after tagging a new release.
-VERSION := 3.0.2+
+VERSION := 3.0.3+
 
 DESTDIR :=
 PREFIX := /usr


### PR DESCRIPTION
## Changes
Fixed deadlock when using ksm throttle.
Overrided the default golang panic to printing a full
traceback to allow crash-handling programs like
apport to log the details.

- ksm: Fix deadlock
- init: coredump on internal error

## Shortlog
3cb3823 ksm: Fix deadlock
e9ba5cb init: coredump on internal error

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>