### PR TITLE
behaviour: Restart on exit

### DIFF
--- a/cc-proxy.service.in
+++ b/cc-proxy.service.in
@@ -5,6 +5,7 @@ Documentation=https://github.com/clearcontainers/proxy
 [Service]
 ExecStart=@libexecdir@/clear-containers/cc-proxy
 LimitNOFILE=infinity
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Specify the restart behaviour in the service file to ensure that if the
proxy exits for any reason (except being told to by `systemctl(1)`), it
will be automatically restarted.

Fixes #152.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>