### PR TITLE
vendor/virtcontainers: update virtcontainers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/containers/virtcontainers"
   packages = ["pkg/hyperstart","pkg/hyperstart/mock"]
-  revision = "0abfabe1aa20c67ee7fce0ad92c2b0ea1fb65196"
+  revision = "24d2e47187feab0a90ceea9294042c48a2312aaf"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"

--- a/vendor/github.com/containers/virtcontainers/.gitignore
+++ b/vendor/github.com/containers/virtcontainers/.gitignore
@@ -1,7 +1,6 @@
 *.patch
 *.o
 /hack/virtc/virtc
-/pause/pause
 /hook/mock/hook
 /shim/mock/shim
 profile.cov

--- a/vendor/github.com/containers/virtcontainers/CONTRIBUTING.md
+++ b/vendor/github.com/containers/virtcontainers/CONTRIBUTING.md
@@ -46,6 +46,28 @@ Note, that the body of the message should not just be a continuation of the subj
 
 It is recommended that each of your patches fixes one thing. Smaller patches are easier to review, and are thus more likely to be accepted and merged, and problems are more likely to be picked up during review.
 
+### Breaking compatibility
+
+In case the patch you submit will break virtcontainers CI, because Clear Containers runtime compatibility is tested through the CI, you have to specify which repository and which pull request it depends on.
+
+Using a simple tag `Depends-on:` in your commit message will allow virtcontainers CI to run properly. Notice that this tag is parsed from the latest commit of the pull request.
+
+For example:
+
+```
+    pod: Remove token from Cmd structure
+    
+    The token and pid data will be hold by the new Process structure and
+    they are related to a container.
+    
+    Depends-on: github.com/clearcontainers/runtime#75
+    
+    Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>
+```
+
+In this example, we want our CI scripts to fetch the pull request 75 of the runtime repository.
+
+
 ## Pull requests
 
 We accept [github pull requests](https://github.com/containers/virtcontainers/pulls).

--- a/vendor/github.com/containers/virtcontainers/Gopkg.lock
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.lock
@@ -2,25 +2,21 @@
 
 
 [[projects]]
-  branch = "master"
   name = "github.com/01org/ciao"
-  packages = ["qemu","ssntp/uuid"]
-  revision = "44068003db570d97b20b7de0ed0686a9eee0cc0f"
+  packages = ["qemu"]
+  revision = "b2a8a2ecea1318ae28a0861191ec385532491b5a"
 
 [[projects]]
   name = "github.com/clearcontainers/proxy"
   packages = ["api","client"]
   revision = "1d2a6a3ea132a86abd0731408b7dc34f2fc17d55"
-  version = "3.0.1"
 
 [[projects]]
-  branch = "master"
   name = "github.com/containernetworking/cni"
   packages = ["libcni","pkg/invoke","pkg/types","pkg/types/020","pkg/types/current","pkg/version"]
   revision = "ff7c3e02e3c212f63a642ad64a5ed22ee54450bd"
 
 [[projects]]
-  branch = "master"
   name = "github.com/containernetworking/plugins"
   packages = ["pkg/ns"]
   revision = "e256564546e8d1ca8a36911f8445c11929043221"
@@ -35,28 +31,23 @@
   name = "github.com/go-ini/ini"
   packages = ["."]
   revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
-  version = "v1.28.2"
 
 [[projects]]
-  branch = "master"
   name = "github.com/kubernetes-incubator/cri-o"
   packages = ["pkg/annotations"]
   revision = "3394b3b2d6af0e41d185bb695c6378be5dd4d61d"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   revision = "d0303fe809921458f417bcf828397a65db30a7e4"
 
 [[projects]]
-  branch = "master"
   name = "github.com/opencontainers/runc"
   packages = ["libcontainer/configs"]
   revision = "0351df1c5a66838d0c392b4ac4cf9450de844e2d"
 
 [[projects]]
-  branch = "master"
   name = "github.com/opencontainers/runtime-spec"
   packages = ["specs-go"]
   revision = "a8125598b32a65ff55c83214d3c262383178e7fa"
@@ -68,43 +59,36 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
 
 [[projects]]
-  branch = "master"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
   revision = "890a5c3458b43e6104ff5da8dfa139d013d77544"
 
 [[projects]]
-  branch = "master"
   name = "github.com/urfave/cli"
   packages = ["."]
   revision = "ac249472b7de27a9e8990819566d9be95ab5b816"
 
 [[projects]]
-  branch = "master"
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
-  revision = "177f1ceba557262b3f1c3aba4df93a29199fb4eb"
+  revision = "b7fbf1f5291ecf8ae5179d3202e914cb98cfe400"
 
 [[projects]]
-  branch = "master"
   name = "github.com/vishvananda/netns"
   packages = ["."]
   revision = "86bef332bfc3b59b7624a600bd53009ce91a9829"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/crypto"
   packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/terminal"]
   revision = "76eec36fa14229c4b25bb894c2d0e591527af429"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
   revision = "314a259e304ff91bd6985da2a7149bbf91237993"
@@ -112,6 +96,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "816c27aebbceeb9114fedaaa611e86d5595c9bf1170f163adb8556f564576e81"
+  inputs-digest = "82781172d7b56c5605cb416f72f21b8cd71ae5f49ef87cfe940e8f7b3d0f3c21"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/containers/virtcontainers/Gopkg.toml
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.toml
@@ -64,72 +64,75 @@
 ## what source location any dependent projects specify.
 # source = "https://github.com/myfork/package.git"
 
-
-
 [[constraint]]
-  branch = "master"
-  name = "github.com/01org/ciao"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/clearcontainers/proxy"
+  revision = "1d2a6a3ea132a86abd0731408b7dc34f2fc17d55"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/containernetworking/cni"
+  revision = "ff7c3e02e3c212f63a642ad64a5ed22ee54450bd"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/containernetworking/plugins"
+  revision = "e256564546e8d1ca8a36911f8445c11929043221"
 
 [[constraint]]
-  branch = "master"
+  name = "github.com/davecgh/go-spew"
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+
+[[constraint]]
+  name = "github.com/go-ini/ini"
+  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
+
+[[constraint]]
   name = "github.com/kubernetes-incubator/cri-o"
+  revision = "3394b3b2d6af0e41d185bb695c6378be5dd4d61d"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/mitchellh/mapstructure"
+  revision = "d0303fe809921458f417bcf828397a65db30a7e4"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/opencontainers/runc"
+  revision = "0351df1c5a66838d0c392b4ac4cf9450de844e2d"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/opencontainers/runtime-spec"
+  revision = "a8125598b32a65ff55c83214d3c262383178e7fa"
 
 [[constraint]]
   name = "github.com/pmezard/go-difflib"
-  version = "1.0.0"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/stretchr/testify"
+  revision = "890a5c3458b43e6104ff5da8dfa139d013d77544"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/urfave/cli"
+  revision = "ac249472b7de27a9e8990819566d9be95ab5b816"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/vishvananda/netlink"
+  revision = "b7fbf1f5291ecf8ae5179d3202e914cb98cfe400"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/vishvananda/netns"
+  revision = "86bef332bfc3b59b7624a600bd53009ce91a9829"
 
 [[constraint]]
-  branch = "master"
   name = "golang.org/x/crypto"
+  revision = "76eec36fa14229c4b25bb894c2d0e591527af429"
 
 [[constraint]]
-  branch = "master"
   name = "golang.org/x/sys"
+  revision = "314a259e304ff91bd6985da2a7149bbf91237993"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/sirupsen/logrus"
+  revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
+
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/go-ini/ini"
+  name = "github.com/01org/ciao"
+  revision = "b2a8a2ecea1318ae28a0861191ec385532491b5a"

--- a/vendor/github.com/containers/virtcontainers/Makefile
+++ b/vendor/github.com/containers/virtcontainers/Makefile
@@ -4,8 +4,6 @@ VC_BIN_DIR := $(BIN_DIR)/virtcontainers/bin
 TEST_BIN_DIR := $(VC_BIN_DIR)/test
 VIRTC_DIR := hack/virtc
 VIRTC_BIN := virtc
-PAUSE_DIR := pause
-PAUSE_BIN := pause
 HOOK_DIR := hook/mock
 HOOK_BIN := hook
 SHIM_DIR := shim/mock
@@ -31,16 +29,13 @@ build:
 virtc:
 	$(QUIET_GOBUILD)go build -o $(VIRTC_DIR)/$@ $(VIRTC_DIR)/*.go
 
-pause:
-	$(QUIET_GOBUILD)go build -o $(PAUSE_DIR)/$(PAUSE_BIN) pause/*.go
-
 hook:
 	$(QUIET_GOBUILD)go build -o $(HOOK_DIR)/$@ $(HOOK_DIR)/*.go
 
 shim:
 	$(QUIET_GOBUILD)go build -o $(SHIM_DIR)/$@ $(SHIM_DIR)/*.go
 
-binaries: virtc pause hook shim
+binaries: virtc hook shim
 
 #
 # Tests
@@ -71,7 +66,6 @@ endef
 install:
 	@mkdir -p $(VC_BIN_DIR)
 	$(call INSTALL_EXEC,$(VIRTC_DIR)/$(VIRTC_BIN))
-	$(call INSTALL_EXEC,$(PAUSE_DIR)/$(PAUSE_BIN))
 	@mkdir -p $(TEST_BIN_DIR)
 	$(call INSTALL_TEST_EXEC,$(HOOK_DIR)/$(HOOK_BIN))
 	$(call INSTALL_TEST_EXEC,$(SHIM_DIR)/$(SHIM_BIN))
@@ -90,7 +84,6 @@ endef
 
 uninstall:
 	$(call UNINSTALL_EXEC,$(VIRTC_BIN))
-	$(call UNINSTALL_EXEC,$(PAUSE_BIN))
 	$(call UNINSTALL_TEST_EXEC,$(HOOK_BIN))
 	$(call UNINSTALL_TEST_EXEC,$(SHIM_BIN))
 
@@ -100,7 +93,6 @@ uninstall:
 
 clean:
 	rm -f $(VIRTC_DIR)/$(VIRTC_BIN)
-	rm -f $(PAUSE_DIR)/$(PAUSE_BIN)
 	rm -f $(HOOK_DIR)/$(HOOK_BIN)
 	rm -f $(SHIM_DIR)/$(SHIM_BIN)
 
@@ -108,7 +100,6 @@ clean:
 	all \
 	build \
 	virtc \
-	pause \
 	hook \
 	shim \
 	binaries \

--- a/vendor/github.com/containers/virtcontainers/NEWS
+++ b/vendor/github.com/containers/virtcontainers/NEWS
@@ -1,3 +1,11 @@
+1.0.4:
+	Added shim debug output
+	Added support for custom qemu accelerators
+	Added structured logging
+	Added drive hotplug support for all containers
+	Fixed pod block index accounting
+	Fixed vendoring model
+
 1.0.3:
 	Added initial device assignment framework
 	Added VFIO devices assignment initial support

--- a/vendor/github.com/containers/virtcontainers/README.md
+++ b/vendor/github.com/containers/virtcontainers/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/containers/virtcontainers.svg?branch=master)](https://travis-ci.org/containers/virtcontainers)
-[![Build Status](https://semaphoreci.com/api/v1/clearcontainers/virtcontainers/branches/master/shields_badge.svg)](https://semaphoreci.com/clearcontainers/virtcontainers)
+[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-16-04-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-16-04-master)
+[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-17-04-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-ubuntu-17-04-master)
+[![Build Status](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-fedora-26-master/badge/icon)](http://cc-jenkins-ci.westus2.cloudapp.azure.com/job/virtcontainers-fedora-26-master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/containers/virtcontainers)](https://goreportcard.com/report/github.com/containers/virtcontainers)
 [![Coverage Status](https://coveralls.io/repos/github/containers/virtcontainers/badge.svg?branch=master)](https://coveralls.io/github/containers/virtcontainers?branch=master)
 [![GoDoc](https://godoc.org/github.com/containers/virtcontainers?status.svg)](https://godoc.org/github.com/containers/virtcontainers)

--- a/vendor/github.com/containers/virtcontainers/agent.go
+++ b/vendor/github.com/containers/virtcontainers/agent.go
@@ -26,6 +26,22 @@ import (
 // AgentType describes the type of guest agent a Pod should run.
 type AgentType string
 
+// ProcessListOptions contains the options used to list running
+// processes inside the container
+type ProcessListOptions struct {
+	// Format describes the output format to list the running processes.
+	// Formats are unrelated to ps(1) formats, only two formats can be specified:
+	// "json" and "table"
+	Format string
+
+	// Args contains the list of arguments to run ps(1) command.
+	// If Args is empty the agent will use "-ef" as options to ps(1).
+	Args []string
+}
+
+// ProcessList represents the list of running processes inside the container
+type ProcessList []byte
+
 const (
 	// NoopAgentType is the No-Op agent.
 	NoopAgentType AgentType = "noop"
@@ -146,4 +162,7 @@ type agent interface {
 	// container related to a Pod. If all is true, all processes in
 	// the container will be sent the signal.
 	killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error
+
+	// processListContainer will list the processes running inside the container
+	processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error)
 }

--- a/vendor/github.com/containers/virtcontainers/api_test.go
+++ b/vendor/github.com/containers/virtcontainers/api_test.go
@@ -29,9 +29,7 @@ import (
 )
 
 const (
-	testHyperstartPausePath    = "/tmp/bundles/pause_bundle/rootfs/bin"
-	testHyperstartPauseBinName = "pause"
-	containerID                = "1"
+	containerID = "1"
 )
 
 var podAnnotations = map[string]string{
@@ -367,14 +365,7 @@ func TestStartPodHyperstartAgentSuccessful(t *testing.T) {
 
 	config := newTestPodConfigHyperstartAgent()
 
-	pauseBinPath := filepath.Join(testDir, testHyperstartPauseBinName)
-	_, err := os.Create(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hyperConfig := config.AgentConfig.(HyperConfig)
-	hyperConfig.PauseBinPath = pauseBinPath
 	config.AgentConfig = hyperConfig
 
 	p, _, err := createAndStartPod(config)
@@ -386,11 +377,6 @@ func TestStartPodHyperstartAgentSuccessful(t *testing.T) {
 	assert.True(t, ok)
 
 	pImpl.agent.(*hyper).bindUnmountAllRootfs(*pImpl)
-
-	err = os.Remove(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestStartPodFailing(t *testing.T) {
@@ -489,14 +475,7 @@ func TestStopPodHyperstartAgentSuccessful(t *testing.T) {
 
 	config := newTestPodConfigHyperstartAgent()
 
-	pauseBinPath := filepath.Join(testDir, testHyperstartPauseBinName)
-	_, err := os.Create(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hyperConfig := config.AgentConfig.(HyperConfig)
-	hyperConfig.PauseBinPath = pauseBinPath
 	config.AgentConfig = hyperConfig
 
 	p, _, err := createAndStartPod(config)
@@ -506,11 +485,6 @@ func TestStopPodHyperstartAgentSuccessful(t *testing.T) {
 
 	p, err = StopPod(p.ID())
 	if p == nil || err != nil {
-		t.Fatal(err)
-	}
-
-	err = os.Remove(pauseBinPath)
-	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -553,14 +527,7 @@ func TestRunPodHyperstartAgentSuccessful(t *testing.T) {
 
 	config := newTestPodConfigHyperstartAgent()
 
-	pauseBinPath := filepath.Join(testDir, testHyperstartPauseBinName)
-	_, err := os.Create(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hyperConfig := config.AgentConfig.(HyperConfig)
-	hyperConfig.PauseBinPath = pauseBinPath
 	config.AgentConfig = hyperConfig
 
 	p, err := RunPod(config)
@@ -578,11 +545,6 @@ func TestRunPodHyperstartAgentSuccessful(t *testing.T) {
 	assert.True(t, ok)
 
 	pImpl.agent.(*hyper).bindUnmountAllRootfs(*pImpl)
-
-	err = os.Remove(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestRunPodFailing(t *testing.T) {
@@ -702,7 +664,7 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 			{
 				ID: containerID,
 				State: State{
-					State: StateStopped,
+					State: StateRunning,
 					URL:   "",
 				},
 				PID:         1000,
@@ -1072,14 +1034,7 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 	contID := "100"
 	config := newTestPodConfigHyperstartAgent()
 
-	pauseBinPath := filepath.Join(testDir, testHyperstartPauseBinName)
-	_, err := os.Create(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hyperConfig := config.AgentConfig.(HyperConfig)
-	hyperConfig.PauseBinPath = pauseBinPath
 	config.AgentConfig = hyperConfig
 
 	p, podDir, err := createAndStartPod(config)
@@ -1114,11 +1069,6 @@ func TestStartStopContainerHyperstartAgentSuccessful(t *testing.T) {
 	assert.True(t, ok)
 
 	pImpl.agent.(*hyper).bindUnmountAllRootfs(*pImpl)
-
-	err = os.Remove(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestStartStopPodHyperstartAgentSuccessfulWithCNINetwork(t *testing.T) {
@@ -1130,14 +1080,7 @@ func TestStartStopPodHyperstartAgentSuccessfulWithCNINetwork(t *testing.T) {
 
 	config := newTestPodConfigHyperstartAgentCNINetwork()
 
-	pauseBinPath := filepath.Join(testDir, testHyperstartPauseBinName)
-	_, err := os.Create(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hyperConfig := config.AgentConfig.(HyperConfig)
-	hyperConfig.PauseBinPath = pauseBinPath
 	config.AgentConfig = hyperConfig
 
 	p, _, err := createAndStartPod(config)
@@ -1154,11 +1097,6 @@ func TestStartStopPodHyperstartAgentSuccessfulWithCNINetwork(t *testing.T) {
 	if p == nil || err != nil {
 		t.Fatal(err)
 	}
-
-	err = os.Remove(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestStartStopPodHyperstartAgentSuccessfulWithCNMNetwork(t *testing.T) {
@@ -1168,14 +1106,7 @@ func TestStartStopPodHyperstartAgentSuccessfulWithCNMNetwork(t *testing.T) {
 
 	config := newTestPodConfigHyperstartAgentCNMNetwork()
 
-	pauseBinPath := filepath.Join(testDir, testHyperstartPauseBinName)
-	_, err := os.Create(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hyperConfig := config.AgentConfig.(HyperConfig)
-	hyperConfig.PauseBinPath = pauseBinPath
 	config.AgentConfig = hyperConfig
 
 	p, _, err := createAndStartPod(config)
@@ -1190,11 +1121,6 @@ func TestStartStopPodHyperstartAgentSuccessfulWithCNMNetwork(t *testing.T) {
 
 	v, err = DeletePod(p.ID())
 	if v == nil || err != nil {
-		t.Fatal(err)
-	}
-
-	err = os.Remove(pauseBinPath)
-	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1322,14 +1248,7 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 	contID := "100"
 	config := newTestPodConfigHyperstartAgent()
 
-	pauseBinPath := filepath.Join(testDir, testHyperstartPauseBinName)
-	_, err := os.Create(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	hyperConfig := config.AgentConfig.(HyperConfig)
-	hyperConfig.PauseBinPath = pauseBinPath
 	config.AgentConfig = hyperConfig
 
 	p, podDir, err := createAndStartPod(config)
@@ -1371,11 +1290,6 @@ func TestEnterContainerHyperstartAgentSuccessful(t *testing.T) {
 	assert.True(t, ok)
 
 	pImpl.agent.(*hyper).bindUnmountAllRootfs(*pImpl)
-
-	err = os.Remove(pauseBinPath)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestEnterContainerFailingNoPod(t *testing.T) {
@@ -1548,6 +1462,8 @@ func TestStatusContainerStateReady(t *testing.T) {
 		Annotations: containerAnnotations,
 	}
 
+	defer p2.wg.Wait()
+
 	status, err := statusContainer(p2, contID)
 	if err != nil {
 		t.Fatal(err)
@@ -1612,13 +1528,15 @@ func TestStatusContainerStateRunning(t *testing.T) {
 	expectedStatus := ContainerStatus{
 		ID: contID,
 		State: State{
-			State: StateStopped,
+			State: StateRunning,
 			URL:   "",
 		},
 		PID:         1000,
 		RootFs:      filepath.Join(testDir, testBundle),
 		Annotations: containerAnnotations,
 	}
+
+	defer p2.wg.Wait()
 
 	status, err := statusContainer(p2, contID)
 	if err != nil {
@@ -1654,6 +1572,51 @@ func TestStatusContainerFailing(t *testing.T) {
 	if err == nil {
 		t.Fatal()
 	}
+}
+
+func TestProcessListContainer(t *testing.T) {
+	cleanUp()
+
+	assert := assert.New(t)
+
+	contID := "abc"
+	options := ProcessListOptions{
+		Format: "json",
+		Args:   []string{"-ef"},
+	}
+
+	_, err := ProcessListContainer("", "", options)
+	assert.Error(err)
+
+	_, err = ProcessListContainer("xyz", "", options)
+	assert.Error(err)
+
+	_, err = ProcessListContainer("xyz", "xyz", options)
+	assert.Error(err)
+
+	config := newTestPodConfigNoop()
+	p, err := CreatePod(config)
+	assert.NoError(err)
+	assert.NotNil(p)
+
+	pImpl, ok := p.(*Pod)
+	assert.True(ok)
+	defer os.RemoveAll(pImpl.configPath)
+
+	contConfig := newTestContainerConfigNoop(contID)
+	_, c, err := CreateContainer(p.ID(), contConfig)
+	assert.NoError(err)
+	assert.NotNil(c)
+
+	_, err = ProcessListContainer(pImpl.id, "xyz", options)
+	assert.Error(err)
+
+	_, err = ProcessListContainer("xyz", contID, options)
+	assert.Error(err)
+
+	_, err = ProcessListContainer(pImpl.id, contID, options)
+	// Pod not running, impossible to ps the container
+	assert.Error(err)
 }
 
 /*
@@ -1818,13 +1781,9 @@ func createStartStopDeleteContainers(b *testing.B, podConfig PodConfig, contConf
 	}
 }
 
-var benchmarkHyperConfig = HyperConfig{
-	PauseBinPath: filepath.Join(testHyperstartPausePath, testHyperstartPauseBinName),
-}
-
 func BenchmarkCreateStartStopDeletePodQemuHypervisorHyperstartAgentNetworkCNI(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, benchmarkHyperConfig, CNINetworkModel)
+		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, CNINetworkModel)
 		createStartStopDeletePod(b, podConfig)
 	}
 }
@@ -1838,7 +1797,7 @@ func BenchmarkCreateStartStopDeletePodQemuHypervisorNoopAgentNetworkCNI(b *testi
 
 func BenchmarkCreateStartStopDeletePodQemuHypervisorHyperstartAgentNetworkNoop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, benchmarkHyperConfig, NoopNetworkModel)
+		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, NoopNetworkModel)
 		createStartStopDeletePod(b, podConfig)
 	}
 }
@@ -1859,7 +1818,7 @@ func BenchmarkCreateStartStopDeletePodMockHypervisorNoopAgentNetworkNoop(b *test
 
 func BenchmarkStartStop1ContainerQemuHypervisorHyperstartAgentNetworkNoop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, benchmarkHyperConfig, NoopNetworkModel)
+		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, NoopNetworkModel)
 		contConfigs := createNewContainerConfigs(1)
 		createStartStopDeleteContainers(b, podConfig, contConfigs)
 	}
@@ -1867,7 +1826,7 @@ func BenchmarkStartStop1ContainerQemuHypervisorHyperstartAgentNetworkNoop(b *tes
 
 func BenchmarkStartStop10ContainerQemuHypervisorHyperstartAgentNetworkNoop(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, benchmarkHyperConfig, NoopNetworkModel)
+		podConfig := createNewPodConfig(QemuHypervisor, HyperstartAgent, HyperConfig{}, NoopNetworkModel)
 		contConfigs := createNewContainerConfigs(10)
 		createStartStopDeleteContainers(b, podConfig, contConfigs)
 	}

--- a/vendor/github.com/containers/virtcontainers/cc_proxy.go
+++ b/vendor/github.com/containers/virtcontainers/cc_proxy.go
@@ -20,11 +20,19 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"time"
 
 	"github.com/clearcontainers/proxy/client"
+	"github.com/sirupsen/logrus"
 )
 
 var defaultCCProxyURL = "unix:///run/cc-oci-runtime/proxy.sock"
+
+const (
+	// Number of seconds to wait for the proxy to respond to a connection
+	// request.
+	waitForProxyTimeoutSecs = 5.0
+)
 
 type ccProxy struct {
 	client *client.Client
@@ -34,6 +42,58 @@ type ccProxy struct {
 // the Clear Containers proxy initialization.
 type CCProxyConfig struct {
 	URL string
+}
+
+// connectProxyRetry repeatedly tries to connect to the proxy on the specified
+// address until a timeout state is reached, when it will fail.
+func (p *ccProxy) connectProxyRetry(scheme, address string) (conn net.Conn, err error) {
+	attempt := 1
+
+	timeoutSecs := time.Duration(waitForProxyTimeoutSecs * time.Second)
+
+	startTime := time.Now()
+	lastLogTime := startTime
+
+	for {
+		conn, err = net.Dial(scheme, address)
+		if err == nil {
+			// If the initial connection was unsuccessful,
+			// ensure a log message is generated when successfully
+			// connected.
+			if attempt > 1 {
+				proxyLogger().WithField("attempt", fmt.Sprintf("%d", attempt)).Info("Connected to proxy")
+			}
+
+			return conn, nil
+		}
+
+		attempt++
+
+		now := time.Now()
+
+		delta := now.Sub(startTime)
+		remaining := timeoutSecs - delta
+
+		if remaining <= 0 {
+			return nil, fmt.Errorf("failed to connect to proxy after %v: %v", timeoutSecs, err)
+		}
+
+		logDelta := now.Sub(lastLogTime)
+		logDeltaSecs := logDelta / time.Second
+
+		if logDeltaSecs >= 1 {
+			proxyLogger().WithError(err).WithFields(logrus.Fields{
+				"attempt":             fmt.Sprintf("%d", attempt),
+				"proxy-network":       scheme,
+				"proxy-address":       address,
+				"remaining-time-secs": fmt.Sprintf("%2.2f", remaining.Seconds()),
+			}).Warning("Retrying proxy connection")
+
+			lastLogTime = now
+		}
+
+		time.Sleep(time.Duration(100) * time.Millisecond)
+	}
 }
 
 func (p *ccProxy) connectProxy(proxyURL string) (*client.Client, error) {
@@ -59,7 +119,7 @@ func (p *ccProxy) connectProxy(proxyURL string) (*client.Client, error) {
 		address = u.Path
 	}
 
-	conn, err := net.Dial(u.Scheme, address)
+	conn, err := p.connectProxyRetry(u.Scheme, address)
 	if err != nil {
 		return nil, err
 	}
@@ -207,9 +267,5 @@ func (p *ccProxy) sendCmd(cmd interface{}) (interface{}, error) {
 		tokens = append(tokens, proxyCmd.token)
 	}
 
-	if _, err := p.client.HyperWithTokens(proxyCmd.cmd, tokens, proxyCmd.message); err != nil {
-		return nil, err
-	}
-
-	return nil, nil
+	return p.client.HyperWithTokens(proxyCmd.cmd, tokens, proxyCmd.message)
 }

--- a/vendor/github.com/containers/virtcontainers/cc_shim.go
+++ b/vendor/github.com/containers/virtcontainers/cc_shim.go
@@ -59,7 +59,11 @@ func (s *ccShim) start(pod Pod, params ShimParams) (int, error) {
 		return -1, fmt.Errorf("URL cannot be empty")
 	}
 
-	args := []string{config.Path, "-t", params.Token, "-u", params.URL}
+	if params.Container == "" {
+		return -1, fmt.Errorf("Container cannot be empty")
+	}
+
+	args := []string{config.Path, "-c", params.Container, "-t", params.Token, "-u", params.URL}
 	if config.Debug {
 		args = append(args, "-d")
 	}

--- a/vendor/github.com/containers/virtcontainers/cc_shim_test.go
+++ b/vendor/github.com/containers/virtcontainers/cc_shim_test.go
@@ -31,6 +31,9 @@ import (
 	. "github.com/containers/virtcontainers/pkg/mock"
 )
 
+// These tests don't care about the format of the container ID
+const testContainer = "testContainer"
+
 var testShimPath = "/usr/bin/virtcontainers/bin/test/shim"
 var testProxyURL = "foo:///foo/clear-containers/proxy.sock"
 var testWrongConsolePath = "/foo/wrong-console"
@@ -130,6 +133,24 @@ func TestCCShimStartParamsURLEmptyFailure(t *testing.T) {
 	testCCShimStart(t, pod, params, true)
 }
 
+func TestCCShimStartParamsContainerEmptyFailure(t *testing.T) {
+	pod := Pod{
+		config: &PodConfig{
+			ShimType: CCShimType,
+			ShimConfig: CCShimConfig{
+				Path: getMockCCShimBinPath(),
+			},
+		},
+	}
+
+	params := ShimParams{
+		Token: "testToken",
+		URL:   "unix://is/awesome",
+	}
+
+	testCCShimStart(t, pod, params, true)
+}
+
 func TestCCShimStartParamsInvalidCommand(t *testing.T) {
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -175,9 +196,10 @@ func startCCShimStartWithoutConsoleSuccessful(t *testing.T, detach bool) (*os.Fi
 	}
 
 	params := ShimParams{
-		Token:  "testToken",
-		URL:    testProxyURL,
-		Detach: detach,
+		Container: testContainer,
+		Token:     "testToken",
+		URL:       testProxyURL,
+		Detach:    detach,
 	}
 
 	return rStdout, wStdout, saveStdout, pod, params, nil
@@ -335,9 +357,10 @@ func TestCCShimStartWithConsoleSuccessful(t *testing.T) {
 	}
 
 	params := ShimParams{
-		Token:   "testToken",
-		URL:     testProxyURL,
-		Console: console,
+		Container: testContainer,
+		Token:     "testToken",
+		URL:       testProxyURL,
+		Console:   console,
 	}
 
 	testCCShimStart(t, pod, params, false)

--- a/vendor/github.com/containers/virtcontainers/cni.go
+++ b/vendor/github.com/containers/virtcontainers/cni.go
@@ -18,10 +18,16 @@ package virtcontainers
 
 import (
 	cniPlugin "github.com/containers/virtcontainers/pkg/cni"
+	"github.com/sirupsen/logrus"
 )
 
 // cni is a network implementation for the CNI plugin.
 type cni struct{}
+
+// Logger returns a logrus logger appropriate for logging cni messages
+func (n *cni) Logger() *logrus.Entry {
+	return virtLog.WithField("subsystem", "cni")
+}
 
 func (n *cni) addVirtInterfaces(networkNS *NetworkNamespace) error {
 	netPlugin, err := cniPlugin.NewNetworkPlugin()
@@ -37,7 +43,7 @@ func (n *cni) addVirtInterfaces(networkNS *NetworkNamespace) error {
 
 		networkNS.Endpoints[idx].Properties = *result
 
-		virtLog.Infof("AddNetwork results %v", *result)
+		n.Logger().Infof("AddNetwork results %v", *result)
 	}
 
 	return nil

--- a/vendor/github.com/containers/virtcontainers/cnm.go
+++ b/vendor/github.com/containers/virtcontainers/cnm.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/01org/ciao/ssntp/uuid"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	types "github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containers/virtcontainers/pkg/uuid"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 )

--- a/vendor/github.com/containers/virtcontainers/container.go
+++ b/vendor/github.com/containers/virtcontainers/container.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Process gathers data related to a container process.
@@ -125,6 +127,15 @@ type Container struct {
 // ID returns the container identifier string.
 func (c *Container) ID() string {
 	return c.id
+}
+
+// Logger returns a logrus logger appropriate for logging Container messages
+func (c *Container) Logger() *logrus.Entry {
+	return virtLog.WithFields(logrus.Fields{
+		"subsystem":    "container",
+		"container-id": c.id,
+		"pod-id":       c.podID,
+	})
 }
 
 // Pod returns the pod handler related to this container.
@@ -271,7 +282,7 @@ func fetchContainer(pod *Pod, containerID string) (*Container, error) {
 		return nil, err
 	}
 
-	virtLog.Debugf("Container config: %+v", config)
+	pod.Logger().WithField("config", config).Debug("Container config")
 
 	return createContainer(pod, config)
 }
@@ -510,7 +521,7 @@ func (c *Container) start() error {
 		hypervisorCaps := c.pod.hypervisor.capabilities()
 
 		if agentCaps.isBlockDeviceSupported() && hypervisorCaps.isBlockDeviceHotplugSupported() {
-			if err := c.addDrive(false); err != nil {
+			if err := c.hotplugDrive(); err != nil {
 				return err
 			}
 		}
@@ -522,14 +533,13 @@ func (c *Container) start() error {
 	}
 
 	if err = c.pod.agent.startContainer(*(c.pod), *c); err != nil {
-		virtLog.Error("Failed to start container: ", err)
+		c.Logger().WithError(err).Error("Failed to start container")
 
 		if err := c.stop(); err != nil {
-			virtLog.Warn("failed to stop container: ", err)
+			c.Logger().WithError(err).Warn("Failed to stop container")
 		}
 		return err
 	}
-
 	c.storeMounts()
 	c.storeDevices()
 
@@ -552,7 +562,7 @@ func (c *Container) stop() error {
 	// someone try to stop the container, and we don't want to issue an
 	// error in that case. This should be a no-op.
 	if state.State == StateStopped {
-		virtLog.Info("Container already stopped, nothing to do")
+		c.Logger().Info("Container already stopped")
 		return nil
 	}
 
@@ -569,9 +579,10 @@ func (c *Container) stop() error {
 		// If shim is still running something went wrong
 		// Make sure we stop the shim process
 		if running, _ := isShimRunning(c.process.Pid); running {
-			virtLog.Warn("Failed to stop container, stopping dangling shim")
+			l := c.Logger()
+			l.Warn("Failed to stop container so stopping dangling shim")
 			if err := stopShim(c.process.Pid); err != nil {
-				virtLog.Warn("failed to stop shim: ", err)
+				l.WithError(err).Warn("failed to stop shim")
 			}
 		}
 
@@ -662,7 +673,7 @@ func (c *Container) kill(signal syscall.Signal, all bool) error {
 	// and updating the container state, according to the signal.
 	if state.State == StateReady {
 		if signal != syscall.SIGTERM && signal != syscall.SIGKILL {
-			virtLog.Infof("Container ready, sending signal %s is a no-op", signal)
+			c.Logger().WithField("signal", signal).Info("Not sending singal as container already ready")
 			return nil
 		}
 
@@ -696,16 +707,35 @@ func (c *Container) kill(signal syscall.Signal, all bool) error {
 	return nil
 }
 
+func (c *Container) processList(options ProcessListOptions) (ProcessList, error) {
+	state, err := c.fetchState("ps")
+	if err != nil {
+		return nil, err
+	}
+
+	if state.State != StateRunning {
+		return nil, fmt.Errorf("Container not running, impossible to list processes")
+	}
+
+	if _, _, err := c.pod.proxy.connect(*(c.pod), false); err != nil {
+		return nil, err
+	}
+	defer c.pod.proxy.disconnect()
+
+	return c.pod.agent.processListContainer(*(c.pod), *c, options)
+}
+
 func (c *Container) createShimProcess(token, url string, cmd Cmd) (*Process, error) {
 	if c.pod.state.URL != url {
 		return &Process{}, fmt.Errorf("Pod URL %s and URL from proxy %s MUST be identical", c.pod.state.URL, url)
 	}
 
 	shimParams := ShimParams{
-		Token:   token,
-		URL:     url,
-		Console: cmd.Console,
-		Detach:  cmd.Detach,
+		Container: c.id,
+		Token:     token,
+		URL:       url,
+		Console:   cmd.Console,
+		Detach:    cmd.Detach,
 	}
 
 	pid, err := c.pod.shim.start(*(c.pod), shimParams)
@@ -726,7 +756,7 @@ func newProcess(token string, pid int) Process {
 	}
 }
 
-func (c *Container) addDrive(create bool) error {
+func (c *Container) hotplugDrive() error {
 	defer func() {
 		c.setStateRootfsBlockChecked(true)
 	}()
@@ -741,7 +771,11 @@ func (c *Container) addDrive(create bool) error {
 		return err
 	}
 
-	virtLog.Infof("Device details for container %s: Major:%d, Minor:%d, MountPoint:%s", c.id, dev.major, dev.minor, dev.mountPoint)
+	c.Logger().WithFields(logrus.Fields{
+		"device-major": dev.major,
+		"device-minor": dev.minor,
+		"mount-point":  dev.mountPoint,
+	}).Info("device details")
 
 	isDM, err := checkStorageDriver(dev.major, dev.minor)
 	if err != nil {
@@ -758,7 +792,10 @@ func (c *Container) addDrive(create bool) error {
 		return err
 	}
 
-	virtLog.Infof("Block Device path %s detected for container with fstype : %s\n", devicePath, c.id, fsType)
+	c.Logger().WithFields(logrus.Fields{
+		"device-path": devicePath,
+		"fs-type":     fsType,
+	}).Info("Block device detected")
 
 	// Add drive with id as container id
 	devID := fmt.Sprintf("drive-%s", c.id)
@@ -768,18 +805,10 @@ func (c *Container) addDrive(create bool) error {
 		ID:     devID,
 	}
 
-	// if pod in create stage
-	if create {
-		if err := c.pod.hypervisor.addDevice(drive, blockDev); err != nil {
-			return err
-		}
-		c.setStateHotpluggedDrive(false)
-	} else {
-		if err := c.pod.hypervisor.hotplugAddDevice(drive, blockDev); err != nil {
-			return err
-		}
-		c.setStateHotpluggedDrive(true)
+	if err := c.pod.hypervisor.hotplugAddDevice(drive, blockDev); err != nil {
+		return err
 	}
+	c.setStateHotpluggedDrive(true)
 
 	driveIndex, err := c.pod.getAndSetPodBlockIndex()
 	if err != nil {
@@ -807,15 +836,18 @@ func (c *Container) isDriveUsed() bool {
 
 func (c *Container) removeDrive() (err error) {
 	if c.isDriveUsed() && c.state.HotpluggedDrive {
-		virtLog.Infof("Unplugging block device for container %s", c.id)
+		c.Logger().Info("unplugging block device")
 
 		devID := fmt.Sprintf("drive-%s", c.id)
 		drive := Drive{
 			ID: devID,
 		}
 
+		l := c.Logger().WithField("device-id", devID)
+		l.Info("Unplugging block device")
+
 		if err := c.pod.hypervisor.hotplugRemoveDevice(drive, blockDev); err != nil {
-			virtLog.Errorf("Error while unplugging block device : %s", err)
+			l.WithError(err).Info("Failed to unplug block device")
 			return err
 		}
 	}
@@ -825,7 +857,7 @@ func (c *Container) removeDrive() (err error) {
 
 func (c *Container) attachDevices() error {
 	for _, device := range c.devices {
-		if err := device.attach(c.pod.hypervisor); err != nil {
+		if err := device.attach(c.pod.hypervisor, c); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/containers/virtcontainers/container_test.go
+++ b/vendor/github.com/containers/virtcontainers/container_test.go
@@ -213,22 +213,12 @@ func TestContainerAddDriveDir(t *testing.T) {
 		checkStorageDriver = savedFunc
 	}()
 
-	err = container.addDrive(true)
-	if err != nil {
-		t.Fatalf("Error with addDrive :%v", err)
-	}
-
-	if container.state.Fstype == "" || container.state.HotpluggedDrive {
-		t.Fatal()
-	}
-
 	container.state.Fstype = ""
 	container.state.HotpluggedDrive = false
 
-	// hotplugged case, when create is passed as false
-	err = container.addDrive(false)
+	err = container.hotplugDrive()
 	if err != nil {
-		t.Fatalf("Error with addDrive :%v", err)
+		t.Fatalf("Error with hotplugDrive :%v", err)
 	}
 
 	if container.state.Fstype == "" || !container.state.HotpluggedDrive {

--- a/vendor/github.com/containers/virtcontainers/filesystem.go
+++ b/vendor/github.com/containers/virtcontainers/filesystem.go
@@ -22,6 +22,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/sirupsen/logrus"
 )
 
 // podResource is an int representing a pod resource type.
@@ -122,6 +124,11 @@ type resourceStorage interface {
 
 // filesystem is a resourceStorage interface implementation for a local filesystem.
 type filesystem struct {
+}
+
+// Logger returns a logrus logger appropriate for logging filesystem messages
+func (fs *filesystem) Logger() *logrus.Entry {
+	return virtLog.WithField("subsystem", "filesystem")
 }
 
 func (fs *filesystem) createAllResources(pod Pod) (err error) {
@@ -273,7 +280,8 @@ func (fs *filesystem) fetchDeviceFile(file string, devices *[]Device) error {
 
 	var tempDevices []Device
 	for _, d := range typedDevices {
-		virtLog.Infof("Device type found in devices file : %s", d.Type)
+		l := fs.Logger().WithField("device-type", d.Type)
+		l.Info("Device type found")
 
 		switch d.Type {
 		case DeviceVFIO:
@@ -283,7 +291,7 @@ func (fs *filesystem) fetchDeviceFile(file string, devices *[]Device) error {
 				return err
 			}
 			tempDevices = append(tempDevices, &device)
-			virtLog.Infof("VFIO device unmarshalled [%v]", device)
+			l.Infof("VFIO device unmarshalled [%v]", device)
 
 		case DeviceBlock:
 			var device BlockDevice
@@ -292,7 +300,7 @@ func (fs *filesystem) fetchDeviceFile(file string, devices *[]Device) error {
 				return err
 			}
 			tempDevices = append(tempDevices, &device)
-			virtLog.Infof("Block Device unmarshalled [%v]", device)
+			l.Infof("Block Device unmarshalled [%v]", device)
 
 		case DeviceGeneric:
 			var device GenericDevice
@@ -301,7 +309,7 @@ func (fs *filesystem) fetchDeviceFile(file string, devices *[]Device) error {
 				return err
 			}
 			tempDevices = append(tempDevices, &device)
-			virtLog.Infof("Generic device unmarshalled [%v]", device)
+			l.Infof("Generic device unmarshalled [%v]", device)
 
 		default:
 			return fmt.Errorf("Unknown device type, could not unmarshal")

--- a/vendor/github.com/containers/virtcontainers/hyperstart_test.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart_test.go
@@ -17,10 +17,7 @@
 package virtcontainers
 
 import (
-	"io/ioutil"
 	"net"
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -79,41 +76,6 @@ func TestHyperstartValidateOneSocketFailing(t *testing.T) {
 func TestHyperstartValidateNSocketSuccessful(t *testing.T) {
 	testHyperstartValidateNSocket(t, 0, true)
 	testHyperstartValidateNSocket(t, 2, true)
-}
-
-func TestCopyPauseBinarySuccessful(t *testing.T) {
-	tmpDirPath, err := ioutil.TempDir("", "test_shared_dir")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDirPath)
-
-	defaultSharedDir = tmpDirPath
-
-	srcFile, err := ioutil.TempFile("", "test_src_copy")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(srcFile.Name())
-	defer srcFile.Close()
-
-	h := &hyper{
-		config: HyperConfig{
-			PauseBinPath: srcFile.Name(),
-		},
-	}
-
-	dstPath := filepath.Join(defaultSharedDir, testPodID,
-		pauseContainerName, rootfsDir, pauseBinName)
-
-	if err := h.copyPauseBinary(testPodID); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(srcFile.Name())
-
-	if _, err := os.Stat(dstPath); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func testProcessHyperRoute(t *testing.T, route *cniTypes.Route, deviceName string, expected *hyperstart.Route) {

--- a/vendor/github.com/containers/virtcontainers/implementation.go
+++ b/vendor/github.com/containers/virtcontainers/implementation.go
@@ -112,3 +112,8 @@ func (impl *VCImpl) StatusContainer(podID, containerID string) (ContainerStatus,
 func (impl *VCImpl) KillContainer(podID, containerID string, signal syscall.Signal, all bool) error {
 	return KillContainer(podID, containerID, signal, all)
 }
+
+// ProcessListContainer implements the VC function of the same name.
+func (impl *VCImpl) ProcessListContainer(podID, containerID string, options ProcessListOptions) (ProcessList, error) {
+	return ProcessListContainer(podID, containerID, options)
+}

--- a/vendor/github.com/containers/virtcontainers/interfaces.go
+++ b/vendor/github.com/containers/virtcontainers/interfaces.go
@@ -41,6 +41,7 @@ type VC interface {
 	StartContainer(podID, containerID string) (VCContainer, error)
 	StatusContainer(podID, containerID string) (ContainerStatus, error)
 	StopContainer(podID, containerID string) (VCContainer, error)
+	ProcessListContainer(podID, containerID string, options ProcessListOptions) (ProcessList, error)
 }
 
 // VCPod is the Pod interface

--- a/vendor/github.com/containers/virtcontainers/network.go
+++ b/vendor/github.com/containers/virtcontainers/network.go
@@ -19,21 +19,53 @@ package virtcontainers
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
 	"runtime"
+	"time"
 
-	"github.com/01org/ciao/ssntp/uuid"
 	types "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containers/virtcontainers/pkg/uuid"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
 
-// Introduces constants related to network routes.
+// NetInterworkingModel defines the network model connecting
+// the network interface to the virtual machine.
+type NetInterworkingModel int
+
+const (
+	// ModelBridged uses a linux bridge to interconnect
+	// the container interface to the VM. This is the
+	// safe default that works for most cases except
+	// macvlan and ipvlan
+	ModelBridged NetInterworkingModel = iota
+
+	// ModelMacVtap can be used when the Container network
+	// interface can be bridged using macvtap
+	ModelMacVtap
+
+	// ModelEnlightened can be used when the Network plugins
+	// are enlightened to create VM native interfaces
+	// when requested by the runtime
+	// This will be used for vethtap, macvtap, ipvtap
+	ModelEnlightened
+)
+
+// DefaultNetInterworkingModel is a package level default
+// that determines how the VM should be connected to the
+// the container network interface
+var DefaultNetInterworkingModel = ModelMacVtap
+
+// Introduces constants related to networking
 const (
 	defaultRouteDest  = "0.0.0.0/0"
 	defaultRouteLabel = "default"
+	defaultFilePerms  = 0600
+	defaultQlen       = 1500
+	defaultQueues     = 8
 )
 
 type netIfaceAddrs struct {
@@ -45,14 +77,17 @@ type netIfaceAddrs struct {
 type NetworkInterface struct {
 	Name     string
 	HardAddr string
+	Addrs    []netlink.Addr
 }
 
-// NetworkInterfacePair defines a pair between TAP and virtual network interfaces.
+// NetworkInterfacePair defines a pair between VM and virtual network interfaces.
 type NetworkInterfacePair struct {
 	ID        string
 	Name      string
 	VirtIface NetworkInterface
 	TAPIface  NetworkInterface
+	NetInterworkingModel
+	VMFds []*os.File
 }
 
 // NetworkConfig is the network configuration related to a network.
@@ -159,7 +194,7 @@ func runNetworkCommon(networkNSPath string, cb func() error) error {
 func addNetworkCommon(pod Pod, networkNS *NetworkNamespace) error {
 	err := doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
 		for idx := range networkNS.Endpoints {
-			if err := bridgeNetworkPair(&(networkNS.Endpoints[idx].NetPair)); err != nil {
+			if err := xconnectVMNetwork(&(networkNS.Endpoints[idx].NetPair), true); err != nil {
 				return err
 			}
 		}
@@ -176,7 +211,7 @@ func addNetworkCommon(pod Pod, networkNS *NetworkNamespace) error {
 func removeNetworkCommon(networkNS NetworkNamespace) error {
 	return doNetNS(networkNS.NetNsPath, func(_ ns.NetNS) error {
 		for _, endpoint := range networkNS.Endpoints {
-			err := unBridgeNetworkPair(endpoint.NetPair)
+			err := xconnectVMNetwork(&(endpoint.NetPair), false)
 			if err != nil {
 				return err
 			}
@@ -199,6 +234,22 @@ func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Lin
 		newLink = &netlink.Tuntap{
 			LinkAttrs: netlink.LinkAttrs{Name: name},
 			Mode:      netlink.TUNTAP_MODE_TAP,
+		}
+	case (&netlink.Macvtap{}).Type():
+		qlen := expectedLink.Attrs().TxQLen
+		if qlen <= 0 {
+			qlen = defaultQlen
+		}
+		newLink = &netlink.Macvtap{
+			Macvlan: netlink.Macvlan{
+				Mode: netlink.MACVLAN_MODE_BRIDGE,
+				LinkAttrs: netlink.LinkAttrs{
+					Index:       expectedLink.Attrs().Index,
+					Name:        name,
+					TxQLen:      qlen,
+					ParentIndex: expectedLink.Attrs().ParentIndex,
+				},
+			},
 		}
 	default:
 		return nil, fmt.Errorf("Unsupported link type %s", expectedLink.Type())
@@ -230,11 +281,202 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 		if l, ok := link.(*netlink.Veth); ok {
 			return l, nil
 		}
+	case (&netlink.Macvtap{}).Type():
+		if l, ok := link.(*netlink.Macvtap); ok {
+			return l, nil
+		}
 	default:
 		return nil, fmt.Errorf("Unsupported link type %s", expectedLink.Type())
 	}
 
 	return nil, fmt.Errorf("Incorrect link type %s, expecting %s", link.Type(), expectedLink.Type())
+}
+
+func xconnectVMNetwork(netPair *NetworkInterfacePair, connect bool) error {
+	switch DefaultNetInterworkingModel {
+	case ModelBridged:
+		netPair.NetInterworkingModel = ModelBridged
+		if connect {
+			return bridgeNetworkPair(netPair)
+		}
+		return unBridgeNetworkPair(*netPair)
+	case ModelMacVtap:
+		netPair.NetInterworkingModel = ModelMacVtap
+		if connect {
+			return tapNetworkPair(netPair)
+		}
+		return untapNetworkPair(*netPair)
+	case ModelEnlightened:
+		return fmt.Errorf("Unsupported networking model")
+	default:
+		return fmt.Errorf("Invalid networking model")
+	}
+}
+
+func createMacvtapFds(linkIndex int, queues int) ([]*os.File, error) {
+	fds := make([]*os.File, queues)
+
+	//mq support
+	for q := 0; q < queues; q++ {
+
+		tapDev := fmt.Sprintf("/dev/tap%d", linkIndex)
+
+		f, err := os.OpenFile(tapDev, os.O_RDWR, defaultFilePerms)
+		if err != nil {
+			cleanupFds(fds, q)
+			return nil, err
+		}
+		fds[q] = f
+	}
+
+	return fds, nil
+}
+
+// There is a limitation in the linux kernel that prevents a macvtap/macvlan link
+// from getting the correct link index when created in a network namespace
+// https://github.com/clearcontainers/runtime/issues/708
+//
+// Till that bug is fixed we need to pick a random non conflicting index and try to
+// create a link. If that fails, we need to try with another.
+// All the kernel does not check if the link id conflicts with a link id on the host
+// hence we need to offset the link id to prevent any overlaps with the host index
+//
+// Here the kernel will ensure that there is no race condition
+
+const hostLinkOffset = 8192 // Host should not have more than 8k interfaces
+const linkRange = 0xFFFF    // This will allow upto 2^16 containers
+const linkRetries = 128     // The numbers of time we try to find a non conflicting index
+const macvtapWorkaround = true
+
+func createMacVtap(netHandle *netlink.Handle, name string, link netlink.Link) (taplink netlink.Link, err error) {
+
+	if !macvtapWorkaround {
+		taplink, err = createLink(netHandle, name, link)
+		return
+	}
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < linkRetries; i++ {
+		index := hostLinkOffset + (r.Int() & linkRange)
+		link.Attrs().Index = index
+		taplink, err = createLink(netHandle, name, link)
+		if err == nil {
+			break
+		}
+	}
+
+	return
+}
+
+func clearIPs(link netlink.Link, addrs []netlink.Addr) error {
+	for _, addr := range addrs {
+		if err := netlink.AddrDel(link, &addr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setIPs(link netlink.Link, addrs []netlink.Addr) error {
+	for _, addr := range addrs {
+		if err := netlink.AddrAdd(link, &addr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func tapNetworkPair(netPair *NetworkInterfacePair) error {
+	netHandle, err := netlink.NewHandle()
+	if err != nil {
+		return err
+	}
+	defer netHandle.Delete()
+
+	vethLink, err := getLinkByName(netHandle, netPair.VirtIface.Name, &netlink.Veth{})
+	if err != nil {
+		return fmt.Errorf("Could not get veth interface: %s: %s", netPair.VirtIface.Name, err)
+	}
+	vethLinkAttrs := vethLink.Attrs()
+
+	// Attach the macvtap interface to the underlying container
+	// interface. Also picks relevant attributes from the parent
+	tapLink, err := createMacVtap(netHandle, netPair.TAPIface.Name,
+		&netlink.Macvtap{
+			Macvlan: netlink.Macvlan{
+				LinkAttrs: netlink.LinkAttrs{
+					TxQLen:      vethLinkAttrs.TxQLen,
+					ParentIndex: vethLinkAttrs.Index,
+				},
+			},
+		})
+
+	if err != nil {
+		return fmt.Errorf("Could not create TAP interface: %s", err)
+	}
+
+	// Save the veth MAC address to the TAP so that it can later be used
+	// to build the hypervisor command line. This MAC address has to be
+	// the one inside the VM in order to avoid any firewall issues. The
+	// bridge created by the network plugin on the host actually expects
+	// to see traffic from this MAC address and not another one.
+	tapHardAddr := vethLinkAttrs.HardwareAddr
+	netPair.TAPIface.HardAddr = vethLinkAttrs.HardwareAddr.String()
+
+	if err := netHandle.LinkSetMTU(tapLink, vethLinkAttrs.MTU); err != nil {
+		return fmt.Errorf("Could not set TAP MTU %d: %s", vethLinkAttrs.MTU, err)
+	}
+
+	hardAddr, err := net.ParseMAC(netPair.VirtIface.HardAddr)
+	if err != nil {
+		return err
+	}
+	if err := netHandle.LinkSetHardwareAddr(vethLink, hardAddr); err != nil {
+		return fmt.Errorf("Could not set MAC address %s for veth interface %s: %s",
+			netPair.VirtIface.HardAddr, netPair.VirtIface.Name, err)
+	}
+
+	if err := netHandle.LinkSetHardwareAddr(tapLink, tapHardAddr); err != nil {
+		return fmt.Errorf("Could not set MAC address %s for veth interface %s: %s",
+			netPair.VirtIface.HardAddr, netPair.VirtIface.Name, err)
+	}
+
+	if err := netHandle.LinkSetUp(tapLink); err != nil {
+		return fmt.Errorf("Could not enable TAP %s: %s", netPair.TAPIface.Name, err)
+	}
+
+	// Clear the IP addresses from the veth interface to prevent ARP conflict
+	netPair.VirtIface.Addrs, err = netlink.AddrList(vethLink, netlink.FAMILY_V4)
+	if err != nil {
+		return fmt.Errorf("Unable to obtain veth IP addresses: %s", err)
+	}
+
+	if err := clearIPs(vethLink, netPair.VirtIface.Addrs); err != nil {
+		return fmt.Errorf("Unable to clear veth IP addresses: %s", err)
+	}
+
+	if err := netHandle.LinkSetUp(vethLink); err != nil {
+		return fmt.Errorf("Could not enable veth %s: %s", netPair.VirtIface.Name, err)
+	}
+
+	// Note: The underlying interfaces need to be up prior to fd creation.
+
+	// Setup the multiqueue fds to be consumed by QEMU as macvtap cannot
+	// be directly connected.
+	// Ideally we want
+	// netdev.FDs, err = createMacvtapFds(netdev.ID, int(config.SMP.CPUs))
+
+	// We do not have global context here, hence a manifest constant
+	// that matches our minimum vCPU configuration
+	// Another option is to defer this to ciao qemu library which does have
+	// global context but cannot handle errors when setting up the network
+	netPair.VMFds, err = createMacvtapFds(tapLink.Attrs().Index, defaultQueues)
+	if err != nil {
+		return fmt.Errorf("Could not setup macvtap fds %s: %s", netPair.TAPIface, err)
+	}
+
+	return nil
 }
 
 func bridgeNetworkPair(netPair *NetworkInterfacePair) error {
@@ -251,7 +493,7 @@ func bridgeNetworkPair(netPair *NetworkInterfacePair) error {
 
 	vethLink, err := getLinkByName(netHandle, netPair.VirtIface.Name, &netlink.Veth{})
 	if err != nil {
-		return fmt.Errorf("Could not get veth interface: %s", err)
+		return fmt.Errorf("Could not get veth interface %s : %s", netPair.VirtIface.Name, err)
 	}
 
 	vethLinkAttrs := vethLink.Attrs()
@@ -307,6 +549,37 @@ func bridgeNetworkPair(netPair *NetworkInterfacePair) error {
 	return nil
 }
 
+func untapNetworkPair(netPair NetworkInterfacePair) error {
+	netHandle, err := netlink.NewHandle()
+	if err != nil {
+		return err
+	}
+	defer netHandle.Delete()
+
+	tapLink, err := getLinkByName(netHandle, netPair.TAPIface.Name, &netlink.Macvtap{})
+	if err != nil {
+		return fmt.Errorf("Could not get TAP interface %s: %s", netPair.TAPIface.Name, err)
+	}
+
+	if err := netHandle.LinkDel(tapLink); err != nil {
+		return fmt.Errorf("Could not remove TAP %s: %s", netPair.TAPIface.Name, err)
+	}
+
+	vethLink, err := getLinkByName(netHandle, netPair.VirtIface.Name, &netlink.Veth{})
+	if err != nil {
+		// The veth pair is not totally managed by virtcontainers
+		virtLog.Warn("Could not get veth interface %s: %s", netPair.VirtIface.Name, err)
+	} else {
+		if err := netHandle.LinkSetDown(vethLink); err != nil {
+			return fmt.Errorf("Could not disable veth %s: %s", netPair.VirtIface.Name, err)
+		}
+	}
+
+	// Restore the IPs that were cleared
+	err = setIPs(vethLink, netPair.VirtIface.Addrs)
+	return err
+}
+
 func unBridgeNetworkPair(netPair NetworkInterfacePair) error {
 	netHandle, err := netlink.NewHandle()
 	if err != nil {
@@ -347,7 +620,7 @@ func unBridgeNetworkPair(netPair NetworkInterfacePair) error {
 	vethLink, err := getLinkByName(netHandle, netPair.VirtIface.Name, &netlink.Veth{})
 	if err != nil {
 		// The veth pair is not totally managed by virtcontainers
-		virtLog.Warn("Could not get veth interface: %s", err)
+		virtLog.WithError(err).Warn("Could not get veth interface")
 	} else {
 		if err := netHandle.LinkSetDown(vethLink); err != nil {
 			return fmt.Errorf("Could not disable veth %s: %s", netPair.VirtIface.Name, err)
@@ -480,7 +753,7 @@ func createNetworkEndpoints(numOfEndpoints int) (endpoints []Endpoint, err error
 	return endpoints, nil
 }
 
-func getIfacesFromNetNs(networkNSPath string) ([]netIfaceAddrs, error) {
+func getIfacesFromNetNsFilter(networkNSPath string, ipFilter bool) ([]netIfaceAddrs, error) {
 	var netIfaces []netIfaceAddrs
 
 	if networkNSPath == "" {
@@ -499,13 +772,15 @@ func getIfacesFromNetNs(networkNSPath string) ([]netIfaceAddrs, error) {
 				return err
 			}
 
-			// Ignore unconfigured network interfaces
-			// These are either base tunnel devices
-			// that are not namespaced like
-			// gre0, gretap0, sit0, ipip0, tunl0
-			// or incorrectly setup interfaces
-			if (addrs == nil) || (len(addrs) == 0) {
-				continue
+			if ipFilter {
+				// Ignore unconfigured network interfaces
+				// These are either base tunnel devices
+				// that are not namespaced like
+				// gre0, gretap0, sit0, ipip0, tunl0
+				// or incorrectly setup interfaces
+				if (addrs == nil) || (len(addrs) == 0) {
+					continue
+				}
 			}
 
 			netIface := netIfaceAddrs{
@@ -523,6 +798,16 @@ func getIfacesFromNetNs(networkNSPath string) ([]netIfaceAddrs, error) {
 	}
 
 	return netIfaces, nil
+}
+
+func getIfacesFromNetNsAll(networkNSPath string) ([]netIfaceAddrs, error) {
+	// get all interfaces, even those without IP
+	return getIfacesFromNetNsFilter(networkNSPath, false)
+}
+
+func getIfacesFromNetNs(networkNSPath string) ([]netIfaceAddrs, error) {
+	// get only the interfaces with valid IP addrsses
+	return getIfacesFromNetNsFilter(networkNSPath, true)
 }
 
 func getNetIfaceByName(name string, netIfaces []netIfaceAddrs) (net.Interface, error) {

--- a/vendor/github.com/containers/virtcontainers/noop_agent.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent.go
@@ -74,3 +74,8 @@ func (n *noopAgent) stopContainer(pod Pod, c Container) error {
 func (n *noopAgent) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }
+
+// processListContainer is the Noop agent Container ps implementation. It does nothing.
+func (n *noopAgent) processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error) {
+	return nil, nil
+}

--- a/vendor/github.com/containers/virtcontainers/pkg/hyperstart/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/hyperstart/hyperstart.go
@@ -50,6 +50,7 @@ const (
 	SetupInterface  = "setupinterface"
 	SetupRoute      = "setuproute"
 	RemoveContainer = "removecontainer"
+	PsContainer     = "pscontainer"
 )
 
 // CodeList is the map making the relation between a string command
@@ -73,6 +74,7 @@ var CodeList = map[string]uint32{
 	SetupInterface:  SetupInterfaceCode,
 	SetupRoute:      SetupRouteCode,
 	RemoveContainer: RemoveContainerCode,
+	PsContainer:     PsContainerCode,
 }
 
 // Values related to the communication on control channel.

--- a/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
@@ -45,6 +45,7 @@ const (
 	SetupInterfaceCode
 	SetupRouteCode
 	RemoveContainerCode
+	PsContainerCode
 	ProcessAsyncEventCode
 )
 
@@ -74,6 +75,14 @@ type ExecCommand struct {
 // hyperstart to remove a container on the guest.
 type RemoveCommand struct {
 	Container string `json:"container"`
+}
+
+// PsCommand is the structure corresponding to the format expected by
+// hyperstart to list processes of a container on the guest.
+type PsCommand struct {
+	Container string   `json:"container"`
+	Format    string   `json:"format"`
+	PsArgs    []string `json:"psargs"`
 }
 
 // PAECommand is the structure hyperstart can expects to
@@ -123,6 +132,7 @@ type FsmapDescriptor struct {
 	Path         string `json:"path"`
 	ReadOnly     bool   `json:"readOnly"`
 	DockerVolume bool   `json:"dockerVolume"`
+	AbsolutePath bool   `json:"absolutePath"`
 }
 
 // EnvironmentVar holds an environment variable and its value.

--- a/vendor/github.com/containers/virtcontainers/proxy.go
+++ b/vendor/github.com/containers/virtcontainers/proxy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 )
 
 // ProxyType describes a proxy type.
@@ -32,6 +33,10 @@ const (
 	// NoopProxyType is the noopProxy.
 	NoopProxyType ProxyType = "noopProxy"
 )
+
+func proxyLogger() *logrus.Entry {
+	return virtLog.WithField("subsystem", "proxy")
+}
 
 // Set sets a proxy type based on the input string.
 func (pType *ProxyType) Set(value string) error {

--- a/vendor/github.com/containers/virtcontainers/qemu.go
+++ b/vendor/github.com/containers/virtcontainers/qemu.go
@@ -27,7 +27,8 @@ import (
 	"time"
 
 	ciaoQemu "github.com/01org/ciao/qemu"
-	"github.com/01org/ciao/ssntp/uuid"
+	"github.com/containers/virtcontainers/pkg/uuid"
+	"github.com/sirupsen/logrus"
 )
 
 type qmpChannel struct {
@@ -70,6 +71,8 @@ const (
 	// QemuQ35 is the QEMU Q35 machine type
 	QemuQ35 = "q35"
 )
+
+const qmpCapErrMsg = "Failed to negoatiate QMP capabilities"
 
 // Mapping between machine types and QEMU binary paths.
 var qemuPaths = map[string]string{
@@ -123,7 +126,15 @@ const (
 	removeDevice
 )
 
-type qmpLogger struct{}
+type qmpLogger struct {
+	logger *logrus.Entry
+}
+
+func newQMPLogger() qmpLogger {
+	return qmpLogger{
+		logger: virtLog.WithField("subsystem", "qmp"),
+	}
+}
 
 func (l qmpLogger) V(level int32) bool {
 	if level != 0 {
@@ -134,15 +145,15 @@ func (l qmpLogger) V(level int32) bool {
 }
 
 func (l qmpLogger) Infof(format string, v ...interface{}) {
-	virtLog.Infof(format, v...)
+	l.logger.Infof(format, v...)
 }
 
 func (l qmpLogger) Warningf(format string, v ...interface{}) {
-	virtLog.Warnf(format, v...)
+	l.logger.Warnf(format, v...)
 }
 
 func (l qmpLogger) Errorf(format string, v ...interface{}) {
-	virtLog.Errorf(format, v...)
+	l.logger.Errorf(format, v...)
 }
 
 var kernelDefaultParams = []Param{
@@ -181,6 +192,11 @@ var kernelDefaultParamsDebug = []Param{
 	{"debug", ""},
 	{"systemd.show_status", "true"},
 	{"systemd.log_level", "debug"},
+}
+
+// Logger returns a logrus logger appropriate for logging qemu messages
+func (q *qemu) Logger() *logrus.Entry {
+	return virtLog.WithField("subsystem", "qemu")
 }
 
 func (q *qemu) buildKernelParams(config HypervisorConfig) error {
@@ -294,11 +310,28 @@ func (q *qemu) appendSocket(devices []ciaoQemu.Device, socket Socket) []ciaoQemu
 	return devices
 }
 
+func networkModelToQemuType(model NetInterworkingModel) ciaoQemu.NetDeviceType {
+	switch model {
+	case ModelBridged:
+		return ciaoQemu.TAP
+	case ModelMacVtap:
+		return ciaoQemu.MACVTAP
+	//case ModelEnlightened:
+	// Here the Network plugin will create a VM native interface
+	// which could be MacVtap, IpVtap, SRIOV, veth-tap, vhost-user
+	// In these cases we will determine the interface type here
+	// and pass in the native interface through
+	default:
+		//TAP should work for most other cases
+		return ciaoQemu.TAP
+	}
+}
+
 func (q *qemu) appendNetworks(devices []ciaoQemu.Device, endpoints []Endpoint) []ciaoQemu.Device {
 	for idx, endpoint := range endpoints {
 		devices = append(devices,
 			ciaoQemu.NetDevice{
-				Type:          ciaoQemu.TAP,
+				Type:          networkModelToQemuType(endpoint.NetPair.NetInterworkingModel),
 				Driver:        ciaoQemu.VirtioNetPCI,
 				ID:            fmt.Sprintf("network-%d", idx),
 				IFName:        endpoint.NetPair.TAPIface.Name,
@@ -307,6 +340,7 @@ func (q *qemu) appendNetworks(devices []ciaoQemu.Device, endpoints []Endpoint) [
 				Script:        "no",
 				VHost:         true,
 				DisableModern: q.nestedRun,
+				FDs:           endpoint.NetPair.VMFds,
 			},
 		)
 	}
@@ -437,7 +471,7 @@ func (q *qemu) buildPath() error {
 
 	p, ok := qemuPaths[machineType]
 	if !ok {
-		virtLog.Warnf("Unknown machine type %s", machineType)
+		q.Logger().WithField("machine-type", machineType).Warn("Unknown machine type")
 		p = defaultQemuPath
 	}
 
@@ -472,7 +506,7 @@ func (q *qemu) init(config HypervisorConfig) error {
 		return err
 	}
 
-	virtLog.Debugf("Running inside a VM = %v", nested)
+	q.Logger().WithField("inside-vm", fmt.Sprintf("%t", nested)).Debug("Checking nesting environment")
 
 	if config.DisableNestingChecks {
 		//Intentionally ignore the nesting check
@@ -493,21 +527,25 @@ func (q *qemu) qmpMonitor(connectedCh chan struct{}) {
 		q.qmpMonitorCh.wg.Done()
 	}(q)
 
-	cfg := ciaoQemu.QMPConfig{Logger: qmpLogger{}}
+	cfg := ciaoQemu.QMPConfig{Logger: newQMPLogger()}
 	qmp, ver, err := ciaoQemu.QMPStart(q.qmpMonitorCh.ctx, q.qmpMonitorCh.path, cfg, q.qmpMonitorCh.disconnectCh)
 	if err != nil {
-		virtLog.Errorf("Failed to connect to QEMU instance %v", err)
+		q.Logger().WithError(err).Error("Failed to connect to QEMU instance")
 		return
 	}
 
 	q.qmpMonitorCh.qmp = qmp
 
-	virtLog.Infof("QMP version %d.%d.%d", ver.Major, ver.Minor, ver.Micro)
-	virtLog.Infof("QMP capabilities %s", ver.Capabilities)
+	q.Logger().WithFields(logrus.Fields{
+		"qmp-major-version": ver.Major,
+		"qmp-minor-version": ver.Minor,
+		"qmp-micro-version": ver.Micro,
+		"qmp-capabilities":  strings.Join(ver.Capabilities, ","),
+	}).Infof("QMP details")
 
 	err = q.qmpMonitorCh.qmp.ExecuteQMPCapabilities(q.qmpMonitorCh.ctx)
 	if err != nil {
-		virtLog.Errorf("Unable to send qmp_capabilities command: %v", err)
+		q.Logger().WithError(err).Error(qmpCapErrMsg)
 		return
 	}
 
@@ -668,7 +706,7 @@ func (q *qemu) createPod(podConfig PodConfig) error {
 
 // startPod will start the Pod's VM.
 func (q *qemu) startPod(startCh, stopCh chan struct{}) error {
-	strErr, err := ciaoQemu.LaunchQemu(q.qemuConfig, qmpLogger{})
+	strErr, err := ciaoQemu.LaunchQemu(q.qemuConfig, newQMPLogger())
 	if err != nil {
 		return fmt.Errorf("%s", strErr)
 	}
@@ -683,20 +721,20 @@ func (q *qemu) startPod(startCh, stopCh chan struct{}) error {
 
 // stopPod will stop the Pod's VM.
 func (q *qemu) stopPod() error {
-	cfg := ciaoQemu.QMPConfig{Logger: qmpLogger{}}
+	cfg := ciaoQemu.QMPConfig{Logger: newQMPLogger()}
 	q.qmpControlCh.disconnectCh = make(chan struct{})
 	const timeout = time.Duration(10) * time.Second
 
-	virtLog.Info("Stopping Pod")
+	q.Logger().Info("Stopping Pod")
 	qmp, _, err := ciaoQemu.QMPStart(q.qmpControlCh.ctx, q.qmpControlCh.path, cfg, q.qmpControlCh.disconnectCh)
 	if err != nil {
-		virtLog.Errorf("Failed to connect to QEMU instance %v", err)
+		q.Logger().WithError(err).Error("Failed to connect to QEMU instance")
 		return err
 	}
 
 	err = qmp.ExecuteQMPCapabilities(q.qmpMonitorCh.ctx)
 	if err != nil {
-		virtLog.Errorf("Failed to negotiate capabilities with QEMU %v", err)
+		q.Logger().WithError(err).Error(qmpCapErrMsg)
 		return err
 	}
 
@@ -722,14 +760,14 @@ func (q *qemu) togglePausePod(pause bool) error {
 		}
 	}(q)
 
-	cfg := ciaoQemu.QMPConfig{Logger: qmpLogger{}}
+	cfg := ciaoQemu.QMPConfig{Logger: newQMPLogger()}
 
 	// Auto-closed by QMPStart().
 	disconnectCh := make(chan struct{})
 
 	qmp, _, err := ciaoQemu.QMPStart(q.qmpControlCh.ctx, q.qmpControlCh.path, cfg, disconnectCh)
 	if err != nil {
-		virtLog.Errorf("Failed to connect to QEMU instance %v", err)
+		q.Logger().WithError(err).Error("Failed to connect to QEMU instance")
 		return err
 	}
 
@@ -737,7 +775,7 @@ func (q *qemu) togglePausePod(pause bool) error {
 
 	err = qmp.ExecuteQMPCapabilities(q.qmpMonitorCh.ctx)
 	if err != nil {
-		virtLog.Errorf("Failed to negotiate capabilities with QEMU %v", err)
+		q.Logger().WithError(err).Error(qmpCapErrMsg)
 		return err
 	}
 
@@ -755,20 +793,20 @@ func (q *qemu) togglePausePod(pause bool) error {
 }
 
 func (q *qemu) qmpSetup() (*ciaoQemu.QMP, error) {
-	cfg := ciaoQemu.QMPConfig{Logger: qmpLogger{}}
+	cfg := ciaoQemu.QMPConfig{Logger: newQMPLogger()}
 
 	// Auto-closed by QMPStart().
 	disconnectCh := make(chan struct{})
 
 	qmp, _, err := ciaoQemu.QMPStart(q.qmpControlCh.ctx, q.qmpControlCh.path, cfg, disconnectCh)
 	if err != nil {
-		virtLog.Errorf("Failed to connect to QEMU instance %v", err)
+		q.Logger().WithError(err).Error("Failed to connect to QEMU instance")
 		return nil, err
 	}
 
 	err = qmp.ExecuteQMPCapabilities(q.qmpMonitorCh.ctx)
 	if err != nil {
-		virtLog.Errorf("Failed to negotiate capabilities with QEMU %v", err)
+		q.Logger().WithError(err).Error(qmpCapErrMsg)
 		return nil, err
 	}
 

--- a/vendor/github.com/containers/virtcontainers/shim.go
+++ b/vendor/github.com/containers/virtcontainers/shim.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 )
 
 // ShimType describes a shim type.
@@ -41,10 +42,11 @@ var waitForShimTimeout = 5.0
 // ShimParams is the structure providing specific parameters needed
 // for the execution of the shim binary.
 type ShimParams struct {
-	Token   string
-	URL     string
-	Console string
-	Detach  bool
+	Container string
+	Token     string
+	URL       string
+	Console   string
+	Detach    bool
 }
 
 // Set sets a shim type based on the input string.
@@ -102,12 +104,16 @@ func newShimConfig(config PodConfig) interface{} {
 	}
 }
 
+func shimLogger() *logrus.Entry {
+	return virtLog.WithField("subsystem", "shim")
+}
+
 func stopShim(pid int) error {
 	if pid <= 0 {
 		return nil
 	}
 
-	virtLog.Infof("Stopping shim PID %d", pid)
+	shimLogger().WithField("shim-pid", pid).Info("Stopping shim")
 
 	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
 		return err

--- a/vendor/github.com/containers/virtcontainers/sshd.go
+++ b/vendor/github.com/containers/virtcontainers/sshd.go
@@ -203,3 +203,8 @@ func (s *sshd) stopContainer(pod Pod, c Container) error {
 func (s *sshd) killContainer(pod Pod, c Container, signal syscall.Signal, all bool) error {
 	return nil
 }
+
+// processListContainer is the agent Container ps implementation for sshd.
+func (s *sshd) processListContainer(pod Pod, c Container, options ProcessListOptions) (ProcessList, error) {
+	return nil, nil
+}

--- a/vendor/github.com/containers/virtcontainers/utils.go
+++ b/vendor/github.com/containers/virtcontainers/utils.go
@@ -19,6 +19,7 @@ package virtcontainers
 import (
 	"crypto/rand"
 	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -63,4 +64,17 @@ func reverseString(s string) string {
 	}
 
 	return string(r)
+}
+
+func cleanupFds(fds []*os.File, numFds int) {
+
+	maxFds := len(fds)
+
+	if numFds < maxFds {
+		maxFds = numFds
+	}
+
+	for i := 0; i < maxFds; i++ {
+		_ = fds[i].Close()
+	}
 }


### PR DESCRIPTION
This new version of virtcontainers has support for
the ps command

short log:
f4a2ad1 virtc: Fix virtc to make it properly usable
b366203 .ci: Handle cases where backward compatibility is broken
e2f5902 lock: Use shared locking for read only cases
5e18bdf lock: Introduce shared lock possibility
809eb65 readme: update CI build badges
ad66bff ci: Remove chronic from setup.sh
eea3d36 tests: Add test to check attaching block device
dbad689 devices: Try to restore the pod block index in case of failure.
1e69ba9 devices: Add block devices to fsmap and pass them to agent.
86488e2 devices: Change check for block devices.
baeab61 device: Add support for block devices to be passed with --device
0424842 proxy: Retry if unable to connect.
8a625ec qemu: Fix incorrectly formatted log message
8910d1b Networking: Add support for multi-queue mactap
aff0a34 Revendor: netlink library revendoring
b332097 vendor/ciao: update ciao
ec539ad uuid: Remove the ciao uuid package
f76f0aa uuid: Use uuid package from repo instead of ciao.
9602046 uuid: Copy over the uuid package from ciao project.
64aafe1 devices: Pass container to devices.attach
ff99e51 mock: update mock API
48667e6 agent: implement ps command
2576cc0 CI: Add script for jenkins job
c6513bd pause: Remove all things related to pause container
29ffbb5 ci: Add Clear Containers tests to the CI of virtcontainers
d6f13e7 ci: Update virtcontainers code in runtime and proxy
c4e51e8 ci: install dependencies using Clear Containers CI setup
f005780 ci: rename ci-jobs and ci-setup scripts
c236931 qemu: Initialize qmp logger properly
4bd0c5c 1.0.4 release
c490764 container: Rename addDrive to hotplugDrive
e848de5 pod: Hotplug all pod container rootfs with devicemapper
d7e3297 pod: Do not overwrite pod state
8b229ca tests: Add tests to check the changes made to ignore uevent error
6eb81de log: Log devices that are not passed to the container.
8a998f8 devices: Add corner case check for /dev/vfio/vfio
f7d0732 devices: Ignore error from missing sysfs path under /sys/dev
3ae5af6 .ci: Pass go env variables to sudo.
8098674 ci: Fix go-vet errors
ccd0c75 logging: Use structured logging
7867430 logging: Log less by default
c03bca6 Vendoring: Use revision locked vendoring model
971215d ci: Fix call to virtcontainers-setup.sh
1b5888f shim: Pass container ID using CLI option

Fixes #159

Signed-off-by: Julio Montes <julio.montes@intel.com>