### PR TITLE
One proxy per vm

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,7 +20,7 @@
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
-  packages = [".","hooks/test"]
+  packages = [".","hooks/syslog","hooks/test"]
   revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
 
 [[projects]]
@@ -43,6 +43,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f1d5bd3e5b7a9d1bbd32e85fd8442c29375c74b0c94604d0fb105f2b9716f620"
+  inputs-digest = "a6f0a55398c1874ad1bb13259b438d328e5aafd282c3532089133634b3b37853"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/proxy.go
+++ b/proxy.go
@@ -632,7 +632,7 @@ func (proxy *proxy) init() error {
 
 	// Open the proxy socket
 	if proxy.socketPath, err = getSocketPath(); err != nil {
-		return fmt.Errorf("couldn't get a rigth socket path: %v", err)
+		return fmt.Errorf("couldn't get a valid socket path: %v", err)
 	}
 	fds := listenFds()
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -903,20 +903,20 @@ func TestHyperstartResponse(t *testing.T) {
 }
 
 func TestGetSocketPath(t *testing.T) {
-	p, err := getSocketPath()
+	p, err := getSocketPath("")
 	assert.Nil(t, err)
 	assert.Equal(t, p, legacySocketPath)
 
 	// Test for default socket path
 	DefaultSocketPath = "/proxy/socket/path"
-	p, err = getSocketPath()
+	p, err = getSocketPath("")
 	assert.Nil(t, err, err)
 	assert.Equal(t, p, DefaultSocketPath)
 
 	// Test that a passed socket path takes precedence
 	var cliSocketPath = "/cli/proxy/socket/path"
 	ArgSocketPath = &cliSocketPath
-	p, err = getSocketPath()
+	p, err = getSocketPath("")
 	assert.Nil(t, err, err)
 	assert.Equal(t, p, cliSocketPath)
 
@@ -924,7 +924,16 @@ func TestGetSocketPath(t *testing.T) {
 	longPath := make([]byte, socketPathMaxLength+1)
 	cliSocketPath = string(longPath)
 	ArgSocketPath = &cliSocketPath
-	p, err = getSocketPath()
+	p, err = getSocketPath("")
 	assert.NotNil(t, err, err)
 	assert.Equal(t, p, "")
+
+	// reset
+	*ArgSocketPath = ""
+
+	// Ensure specified socket used
+	sp := "/je/suis/un/chemin/de/socket"
+	p, err = getSocketPath(sp)
+	assert.NoError(t, err)
+	assert.Equal(t, sp, p)
 }

--- a/vendor/github.com/sirupsen/logrus/hooks/syslog/README.md
+++ b/vendor/github.com/sirupsen/logrus/hooks/syslog/README.md
@@ -1,0 +1,39 @@
+# Syslog Hooks for Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/>
+
+## Usage
+
+```go
+import (
+  "log/syslog"
+  "github.com/sirupsen/logrus"
+  lSyslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+func main() {
+  log       := logrus.New()
+  hook, err := lSyslog.NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, "")
+
+  if err == nil {
+    log.Hooks.Add(hook)
+  }
+}
+```
+
+If you want to connect to local syslog (Ex. "/dev/log" or "/var/run/syslog" or "/var/run/log"). Just assign empty string to the first two parameters of `NewSyslogHook`. It should look like the following.
+
+```go
+import (
+  "log/syslog"
+  "github.com/sirupsen/logrus"
+  lSyslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+func main() {
+  log       := logrus.New()
+  hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
+
+  if err == nil {
+    log.Hooks.Add(hook)
+  }
+}
+```

--- a/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog.go
@@ -1,0 +1,55 @@
+// +build !windows,!nacl,!plan9
+
+package syslog
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SyslogHook to send logs via syslog.
+type SyslogHook struct {
+	Writer        *syslog.Writer
+	SyslogNetwork string
+	SyslogRaddr   string
+}
+
+// Creates a hook to be added to an instance of logger. This is called with
+// `hook, err := NewSyslogHook("udp", "localhost:514", syslog.LOG_DEBUG, "")`
+// `if err == nil { log.Hooks.Add(hook) }`
+func NewSyslogHook(network, raddr string, priority syslog.Priority, tag string) (*SyslogHook, error) {
+	w, err := syslog.Dial(network, raddr, priority, tag)
+	return &SyslogHook{w, network, raddr}, err
+}
+
+func (hook *SyslogHook) Fire(entry *logrus.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to read entry, %v", err)
+		return err
+	}
+
+	switch entry.Level {
+	case logrus.PanicLevel:
+		return hook.Writer.Crit(line)
+	case logrus.FatalLevel:
+		return hook.Writer.Crit(line)
+	case logrus.ErrorLevel:
+		return hook.Writer.Err(line)
+	case logrus.WarnLevel:
+		return hook.Writer.Warning(line)
+	case logrus.InfoLevel:
+		return hook.Writer.Info(line)
+	case logrus.DebugLevel:
+		return hook.Writer.Debug(line)
+	default:
+		return nil
+	}
+}
+
+func (hook *SyslogHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}

--- a/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog_test.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog_test.go
@@ -1,0 +1,27 @@
+package syslog
+
+import (
+	"log/syslog"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestLocalhostAddAndPrint(t *testing.T) {
+	log := logrus.New()
+	hook, err := NewSyslogHook("udp", "localhost:514", syslog.LOG_INFO, "")
+
+	if err != nil {
+		t.Errorf("Unable to connect to local syslog.")
+	}
+
+	log.Hooks.Add(hook)
+
+	for _, level := range hook.Levels() {
+		if len(log.Hooks[level]) != 1 {
+			t.Errorf("SyslogHook was not added. The length of log.Hooks[%v]: %v", level, len(log.Hooks[level]))
+		}
+	}
+
+	log.Info("Congratulations!")
+}

--- a/vm.go
+++ b/vm.go
@@ -230,8 +230,13 @@ func (vm *vm) ioHyperToClients() {
 
 		session := vm.findSessionBySeq(msg.Session)
 		if session == nil {
-			fmt.Fprintf(os.Stderr,
-				"couldn't find client with seq number %d\n", msg.Session)
+			msg := fmt.Sprintf("couldn't find client with seq number %d", msg.Session)
+
+			if podInstance {
+				vm.logIO.Info(msg)
+			} else {
+				fmt.Fprintln(os.Stderr, msg)
+			}
 			continue
 		}
 


### PR DESCRIPTION
Allow the proxy to be run for a single pod.

This branch allows multiple proxies to be run on a single system, one per pod. Note that it also permits this behaviour even when the proxy is run as a system-level systemd service.
