### PR TITLE
stdin: Forward all stream input coming from the shim

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -515,11 +515,6 @@ func forwardStdin(frame *api.Frame, userData interface{}) error {
 		return errors.New("stdin: client not associated with any I/O session")
 	}
 
-	// Don't try to forward stdin if it is empty.
-	if len(frame.Payload) == 0 {
-		return nil
-	}
-
 	return client.session.ForwardStdin(frame)
 }
 


### PR DESCRIPTION
In case the proxy was getting an empty message through the stdin
stream from the shim, it was not sending anything to the agent.
Unfortunately, doing such a thing was preventing the agent from
receiving EOF on stdin.

This patch removes this special handling case, and forward every
input from the shim to the agent.

Fixes #169