### PR TITLE
release: Clear Containers 3.0.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # The version should be bumped and the '+' sign removed just before tagging a
 # new release.
 # A '+' sign should be added in the commit just after tagging a new release.
-VERSION := 3.0.7+
+VERSION := 3.0.8+
 
 DESTDIR :=
 PREFIX := /usr


### PR DESCRIPTION
- stdin: Forward all stream input coming from the shim
- One proxy per vm

d0cd3c3 stdin: Forward all stream input coming from the shim
bc4d5ca API: Shutdown pod instance on unregister
2386a5a KSM: Only setup when running as system instance
c9af303 logging: Redirect pod instance log output to syslog
8c49c97 logging: Add support for syslog
ff4e478 network: Add URI parameter to getSocketPath()
336cf8e errors: Fix typo in error message

Fixes: #171

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>