### PR TITLE
logging: Ensure journald identifier is simply "cc-proxy"

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -835,7 +835,7 @@ func SetLoggingParams(logLevel string) error {
 		syslogHook, err := lsyslog.NewSyslogHook("",
 			"",
 			syslog.LOG_INFO|syslog.LOG_DAEMON,
-			"")
+			name)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, the identifier used for each proxy log message specified
the full path to the proxy binary. This meant that to select proxy log
messages it was necessary to specify:

```
$ sudo journalctl -t /usr/libexec/clear-containers/cc-proxy
```

Now, the user can perform the same action with a simple:

```
$ sudo journalctl -t cc-proxy
```

Fixes #180.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>