### PR TITLE
vendor: Vendor latest virtcontainers.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,7 @@
 [[projects]]
   name = "github.com/containers/virtcontainers"
   packages = ["pkg/hyperstart","pkg/hyperstart/mock"]
-  revision = "2687abf41549ad806f2bf955b06467254219da5e"
+  revision = "d2342c73a2b486736b2f88164b13b542873115dc"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -43,6 +43,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c6508cfb731879ec47dd8b2ea279dcbc58139d75a6821ab0b93dfdee2cd338a8"
+  inputs-digest = "dcfe8aebc210a8d1b64a73cbb480e4e535ecf2ec945a8bf6bb6846913b1a6d7c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,7 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "2687abf41549ad806f2bf955b06467254219da5e"
+  revision = "d2342c73a2b486736b2f88164b13b542873115dc"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/vendor/github.com/containers/virtcontainers/Gopkg.lock
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.lock
@@ -2,11 +2,6 @@
 
 
 [[projects]]
-  name = "github.com/ciao-project/ciao"
-  packages = ["qemu"]
-  revision = "239f5bc3e8e5fe18e6b4df31dcd692db5692c55f"
-
-[[projects]]
   name = "github.com/clearcontainers/proxy"
   packages = ["api","client"]
   revision = "1d2a6a3ea132a86abd0731408b7dc34f2fc17d55"
@@ -31,6 +26,11 @@
   name = "github.com/go-ini/ini"
   packages = ["."]
   revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
+
+[[projects]]
+  name = "github.com/intel/govmm"
+  packages = ["qemu"]
+  revision = "064ffdb2b27a49feea45eea8db1a6738f5dc4e09"
 
 [[projects]]
   name = "github.com/kubernetes-incubator/cri-o"
@@ -96,6 +96,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3fb911fc813d328a7add909dc0eb35d4d9ea8efc1c8710d2cbcce59efd5ae440"
+  inputs-digest = "08587dd11560c8b455a1a84351761327aeb6195999805d76057a4a816d0f6536"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/containers/virtcontainers/Gopkg.toml
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.toml
@@ -132,7 +132,6 @@
   name = "github.com/sirupsen/logrus"
   revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
 
-
 [[constraint]]
-  name = "github.com/ciao-project/ciao"
-  revision = "239f5bc3e8e5fe18e6b4df31dcd692db5692c55f"
+  name = "github.com/intel/govmm"
+  revision = "064ffdb2b27a49feea45eea8db1a6738f5dc4e09"

--- a/vendor/github.com/containers/virtcontainers/agent.go
+++ b/vendor/github.com/containers/virtcontainers/agent.go
@@ -133,6 +133,22 @@ type agent interface {
 	// to handle all other Agent interface methods.
 	init(pod *Pod, config interface{}) error
 
+	// vmURL returns the agent URL exposed by the hypervisor. This URL has
+	// been previously built from the agent implementation and provided to
+	// the hypervisor through a specific hypervisor interface function. It
+	// represents the entry point to connect to the agent through the VM.
+	// This function is particularly useful in case there is no proxy
+	// needed, meaning the proxy implementation will have to provide this
+	// URL instead of a real proxy URL.
+	vmURL() (string, error)
+
+	// setProxyURL sets the URL virtcontainers should connect in order to
+	// communicate with the agent. This URL can be either the proxy URL
+	// if it actually needs to go through a proxy, or it can be the VM
+	// URL in case no proxy is needed. Both ways, this has to be
+	// transparent for the agent implementation.
+	setProxyURL(url string) error
+
 	// capabilities should return a structure that specifies the capabilities
 	// supported by the agent.
 	capabilities() capabilities

--- a/vendor/github.com/containers/virtcontainers/asset.go
+++ b/vendor/github.com/containers/virtcontainers/asset.go
@@ -1,0 +1,158 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/containers/virtcontainers/pkg/annotations"
+)
+
+type assetType string
+
+func (t assetType) annotations() (string, string, error) {
+	switch t {
+	case kernelAsset:
+		return annotations.KernelPath, annotations.KernelHash, nil
+	case imageAsset:
+		return annotations.ImagePath, annotations.ImageHash, nil
+	case hypervisorAsset:
+		return annotations.HypervisorPath, annotations.HypervisorHash, nil
+	case firmwareAsset:
+		return annotations.FirmwarePath, annotations.FirmwareHash, nil
+	}
+
+	return "", "", fmt.Errorf("Wrong asset type %s", t)
+}
+
+const (
+	kernelAsset     assetType = "kernel"
+	imageAsset      assetType = "image"
+	hypervisorAsset assetType = "hypervisor"
+	firmwareAsset   assetType = "firmware"
+)
+
+type asset struct {
+	path         string
+	computedHash string
+	kind         assetType
+}
+
+func (a *asset) valid() bool {
+	if !filepath.IsAbs(a.path) {
+		return false
+	}
+
+	switch a.kind {
+	case kernelAsset:
+		return true
+	case imageAsset:
+		return true
+	case hypervisorAsset:
+		return true
+	case firmwareAsset:
+		return true
+	}
+
+	return false
+}
+
+// hash returns the hex encoded string for the asset hash
+func (a *asset) hash(hashType string) (string, error) {
+	var hashEncodedLen int
+	var hash string
+
+	// We read the actual asset content
+	bytes, err := ioutil.ReadFile(a.path)
+	if err != nil {
+		return "", err
+	}
+
+	if len(bytes) == 0 {
+		return "", fmt.Errorf("Empty asset file at %s", a.path)
+	}
+
+	// Build the asset hash and convert it to a string.
+	// We only support SHA512 for now.
+	switch hashType {
+	case annotations.SHA512:
+		virtLog.Debugf("Computing %v hash", a.path)
+		hashComputed := sha512.Sum512(bytes)
+		hashEncodedLen = hex.EncodedLen(len(hashComputed))
+		hashEncoded := make([]byte, hashEncodedLen)
+		hex.Encode(hashEncoded, hashComputed[:])
+		hash = string(hashEncoded[:])
+		virtLog.Debugf("%v hash: %s", a.path, hash)
+	default:
+		return "", fmt.Errorf("Invalid hash type %s", hashType)
+	}
+
+	a.computedHash = hash
+
+	return hash, nil
+}
+
+// newAsset returns a new asset from the pod annotations.
+func newAsset(podConfig *PodConfig, t assetType) (*asset, error) {
+	pathAnnotation, hashAnnotation, err := t.annotations()
+	if err != nil {
+		return nil, err
+	}
+
+	if pathAnnotation == "" || hashAnnotation == "" {
+		return nil, fmt.Errorf("Missing annotation paths for %s", t)
+	}
+
+	path, ok := podConfig.Annotations[pathAnnotation]
+	if !ok || path == "" {
+		return nil, nil
+	}
+
+	if !filepath.IsAbs(path) {
+		return nil, fmt.Errorf("%s is not an absolute path", path)
+	}
+
+	a := &asset{path: path, kind: t}
+
+	hash, ok := podConfig.Annotations[hashAnnotation]
+	if !ok || hash == "" {
+		return a, nil
+	}
+
+	// We have a hash annotation, we need to verify the asset against it.
+	hashType, ok := podConfig.Annotations[annotations.AssetHashType]
+	if !ok {
+		virtLog.Warningf("Unrecognized hash type: %s, switching to %s", hashType, annotations.SHA512)
+		hashType = annotations.SHA512
+	}
+
+	hashComputed, err := a.hash(hashType)
+	if err != nil {
+		return a, err
+	}
+
+	// If our computed asset hash does not match the passed annotation, we must exit.
+	if hashComputed != hash {
+		return nil, fmt.Errorf("Invalid hash for %s: computed %s, expecting %s]", a.path, hashComputed, hash)
+	}
+
+	return a, nil
+}

--- a/vendor/github.com/containers/virtcontainers/asset_test.go
+++ b/vendor/github.com/containers/virtcontainers/asset_test.go
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containers/virtcontainers/pkg/annotations"
+	"github.com/stretchr/testify/assert"
+)
+
+var assetContent = []byte("FakeAsset fake asset FAKE ASSET")
+var assetContentHash = "92549f8d2018a95a294d28a65e795ed7d1a9d150009a28cea108ae10101178676f04ab82a6950d0099e4924f9c5e41dcba8ece56b75fc8b4e0a7492cb2a8c880"
+var assetContentWrongHash = "92549f8d2018a95a294d28a65e795ed7d1a9d150009a28cea108ae10101178676f04ab82a6950d0099e4924f9c5e41dcba8ece56b75fc8b4e0a7492cb2a8c881"
+
+func TestAssetWrongHashType(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	assert.Nil(err)
+
+	defer func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name()) // clean up
+	}()
+
+	_, err = tmpfile.Write(assetContent)
+	assert.Nil(err)
+
+	a := &asset{
+		path: tmpfile.Name(),
+	}
+
+	h, err := a.hash("shafoo")
+	assert.Equal(h, "")
+	assert.NotNil(err)
+}
+
+func TestAssetHash(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	assert.Nil(err)
+
+	defer func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name()) // clean up
+	}()
+
+	_, err = tmpfile.Write(assetContent)
+	assert.Nil(err)
+
+	a := &asset{
+		path: tmpfile.Name(),
+	}
+
+	hash, err := a.hash(annotations.SHA512)
+	assert.Nil(err)
+	assert.Equal(assetContentHash, hash)
+	assert.Equal(assetContentHash, a.computedHash)
+}
+
+func TestAssetNew(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	assert.Nil(err)
+
+	defer func() {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name()) // clean up
+	}()
+
+	_, err = tmpfile.Write(assetContent)
+	assert.Nil(err)
+
+	p := &PodConfig{
+		Annotations: map[string]string{
+			annotations.KernelPath: tmpfile.Name(),
+			annotations.KernelHash: assetContentHash,
+		},
+	}
+
+	a, err := newAsset(p, imageAsset)
+	assert.Nil(err)
+	assert.Nil(a)
+
+	a, err = newAsset(p, kernelAsset)
+	assert.Nil(err)
+	assert.Equal(assetContentHash, a.computedHash)
+
+	p = &PodConfig{
+		Annotations: map[string]string{
+			annotations.KernelPath: tmpfile.Name(),
+			annotations.KernelHash: assetContentWrongHash,
+		},
+	}
+
+	a, err = newAsset(p, kernelAsset)
+	assert.NotNil(err)
+}

--- a/vendor/github.com/containers/virtcontainers/bridge.go
+++ b/vendor/github.com/containers/virtcontainers/bridge.go
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import "fmt"
+
+type bridgeType string
+
+const (
+	pciBridge  bridgeType = "pci"
+	pcieBridge            = "pcie"
+)
+
+const pciBridgeMaxCapacity = 30
+
+// Bridge is a bridge where devices can be hot plugged
+type Bridge struct {
+	// Address contains information about devices plugged and its address in the bridge
+	Address map[uint32]string
+
+	// Type is the type of the bridge (pci, pcie, etc)
+	Type bridgeType
+
+	//ID is used to identify the bridge in the hypervisor
+	ID string
+}
+
+// NewBridges creates n new pci(e) bridges depending of the machine type
+func NewBridges(n uint32, machine string) []Bridge {
+	var bridges []Bridge
+	var bt bridgeType
+
+	switch machine {
+	case QemuQ35:
+		// currently only pci bridges are supported
+		// qemu-2.10 will introduce pcie bridges
+		fallthrough
+	case QemuPC:
+		bt = pciBridge
+	default:
+		return nil
+	}
+
+	for i := uint32(0); i < n; i++ {
+		bridges = append(bridges, Bridge{
+			Type:    bt,
+			ID:      fmt.Sprintf("%s-bridge-%d", bt, i),
+			Address: make(map[uint32]string),
+		})
+	}
+
+	return bridges
+}
+
+// addDevice on success adds the device ID to the bridge and return the address
+// where the device was added, otherwise an error is returned
+func (b *Bridge) addDevice(ID string) (uint32, error) {
+	var addr uint32
+
+	// looking for the first available address
+	for i := uint32(1); i <= pciBridgeMaxCapacity; i++ {
+		if _, ok := b.Address[i]; !ok {
+			addr = i
+			break
+		}
+	}
+
+	if addr == 0 {
+		return 0, fmt.Errorf("Unable to hot plug device on bridge: there are not empty slots")
+	}
+
+	// save address and device
+	b.Address[addr] = ID
+	return addr, nil
+}
+
+// removeDevice on success removes the device ID from the bridge and return nil,
+// otherwise an error is returned
+func (b *Bridge) removeDevice(ID string) error {
+	// check if the device was hot plugged in the bridge
+	for addr, devID := range b.Address {
+		if devID == ID {
+			// free address to re-use the same slot with other devices
+			delete(b.Address, addr)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Unable to hot unplug device %s: not present on bridge", ID)
+}

--- a/vendor/github.com/containers/virtcontainers/bridge_test.go
+++ b/vendor/github.com/containers/virtcontainers/bridge_test.go
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBridges(t *testing.T) {
+	assert := assert.New(t)
+	var countBridges uint32 = 1
+
+	bridges := NewBridges(countBridges, "")
+	assert.Nil(bridges)
+
+	bridges = NewBridges(countBridges, QemuQ35)
+	assert.Len(bridges, int(countBridges))
+
+	b := bridges[0]
+	assert.NotEmpty(b.ID)
+	assert.NotNil(b.Address)
+}
+
+func TestAddRemoveDevice(t *testing.T) {
+	assert := assert.New(t)
+	var countBridges uint32 = 1
+
+	// create a bridge
+	bridges := NewBridges(countBridges, "")
+	assert.Nil(bridges)
+	bridges = NewBridges(countBridges, QemuQ35)
+	assert.Len(bridges, int(countBridges))
+
+	// add device
+	devID := "abc123"
+	b := bridges[0]
+	addr, err := b.addDevice(devID)
+	assert.NoError(err)
+	if addr < 1 {
+		assert.Fail("address cannot be less then 1")
+	}
+
+	// remove device
+	err = b.removeDevice("")
+	assert.Error(err)
+
+	err = b.removeDevice(devID)
+	assert.NoError(err)
+}

--- a/vendor/github.com/containers/virtcontainers/cc_proxy_test.go
+++ b/vendor/github.com/containers/virtcontainers/cc_proxy_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCCProxyStart(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpdir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpdir)
+
+	proxy := &ccProxy{}
+
+	type testData struct {
+		pod         Pod
+		expectedURI string
+		expectError bool
+	}
+
+	invalidPath := filepath.Join(tmpdir, "enoent")
+	expectedSocketPath := filepath.Join(runStoragePath, testPodID, "proxy.sock")
+	expectedURI := fmt.Sprintf("unix://%s", expectedSocketPath)
+
+	data := []testData{
+		{Pod{}, "", true},
+		{
+			Pod{
+				config: &PodConfig{
+					ProxyType: "invalid",
+				},
+			}, "", true,
+		},
+		{
+			Pod{
+				config: &PodConfig{
+					ProxyType:   CCProxyType,
+					ProxyConfig: ProxyConfig{
+					// invalid - no path
+					},
+				},
+			}, "", true,
+		},
+		{
+			Pod{
+				config: &PodConfig{
+					ProxyType: CCProxyType,
+					ProxyConfig: ProxyConfig{
+						Path: invalidPath,
+					},
+				},
+			}, "", true,
+		},
+		{
+			Pod{
+				id: testPodID,
+				config: &PodConfig{
+					ProxyType: CCProxyType,
+					ProxyConfig: ProxyConfig{
+						Path: "echo",
+					},
+				},
+			}, expectedURI, false,
+		},
+	}
+
+	for _, d := range data {
+		pid, uri, err := proxy.start(d.pod)
+		if d.expectError {
+			assert.Error(err)
+			continue
+		}
+
+		assert.NoError(err)
+		assert.True(pid > 0)
+		assert.Equal(d.expectedURI, uri)
+	}
+}

--- a/vendor/github.com/containers/virtcontainers/container_test.go
+++ b/vendor/github.com/containers/virtcontainers/container_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetAnnotations(t *testing.T) {
@@ -47,6 +49,28 @@ func TestGetAnnotations(t *testing.T) {
 			t.Fatalf("Expecting ['%s']='%s', Got ['%s']='%s'\n", k, annotations[k], k, v)
 		}
 	}
+}
+
+func TestContainerSystemMountsInfo(t *testing.T) {
+	mounts := []Mount{
+		{
+			Source:      "/dev",
+			Destination: "/dev",
+			Type:        "bind",
+		},
+	}
+
+	c := Container{
+		mounts: mounts,
+	}
+
+	assert.False(t, c.systemMountsInfo.BindMountDev)
+	c.getSystemMountInfo()
+	assert.True(t, c.systemMountsInfo.BindMountDev)
+
+	c.mounts[0].Type = "tmpfs"
+	c.getSystemMountInfo()
+	assert.False(t, c.systemMountsInfo.BindMountDev)
 }
 
 func TestContainerPod(t *testing.T) {

--- a/vendor/github.com/containers/virtcontainers/hyperstart.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart.go
@@ -32,7 +32,7 @@ var defaultSockPathTemplates = []string{"%s/%s/hyper.sock", "%s/%s/tty.sock"}
 var defaultChannelTemplate = "sh.hyper.channel.%d"
 var defaultDeviceIDTemplate = "channel%d"
 var defaultIDTemplate = "charch%d"
-var defaultSharedDir = "/tmp/hyper/shared/pods/"
+var defaultSharedDir = "/run/hyper/shared/pods/"
 var mountTag = "hyperShared"
 var rootfsDir = "rootfs"
 var maxHostnameLen = 64
@@ -339,6 +339,16 @@ func (h *hyper) init(pod *Pod, config interface{}) (err error) {
 	return nil
 }
 
+// vmURL returns VM URL from hyperstart agent implementation.
+func (h *hyper) vmURL() (string, error) {
+	return "", nil
+}
+
+// setProxyURL sets proxy URL for hyperstart agent implementation.
+func (h *hyper) setProxyURL(url string) error {
+	return nil
+}
+
 func (h *hyper) createPod(pod *Pod) (err error) {
 	for _, volume := range h.config.Volumes {
 		err := pod.hypervisor.addDevice(volume, fsDev)
@@ -460,6 +470,8 @@ func (h *hyper) startOneContainer(pod Pod, c Container) error {
 		Rootfs:  rootfsDir,
 		Process: process,
 	}
+
+	container.SystemMountsInfo.BindMountDev = c.systemMountsInfo.BindMountDev
 
 	if c.state.Fstype != "" {
 		driveName, err := getVirtDriveName(c.state.BlockIndex)

--- a/vendor/github.com/containers/virtcontainers/kata_proxy.go
+++ b/vendor/github.com/containers/virtcontainers/kata_proxy.go
@@ -1,0 +1,98 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
+
+// This is the Kata Containers implementation of the proxy interface.
+// This is pretty simple since it provides the same interface to both
+// runtime and shim as if they were talking directly to the agent.
+type kataProxy struct {
+	proxyURL string
+}
+
+// start is kataProxy start implementation for proxy interface.
+func (p *kataProxy) start(pod Pod) (int, string, error) {
+	config, err := newProxyConfig(pod.config)
+	if err != nil {
+		return -1, "", err
+	}
+
+	// construct the socket path the proxy instance will use
+	socketPath := filepath.Join(runStoragePath, pod.id, "kata_proxy.sock")
+	proxyURL := fmt.Sprintf("unix://%s", socketPath)
+
+	vmURL, err := pod.agent.vmURL()
+	if err != nil {
+		return -1, "", err
+	}
+
+	if err := pod.agent.setProxyURL(proxyURL); err != nil {
+		return -1, "", err
+	}
+
+	p.proxyURL = proxyURL
+
+	args := []string{config.Path, "-listen-socket", proxyURL, "-mux-socket", vmURL}
+	if config.Debug {
+		args = append(args, "-log", "debug")
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	if err := cmd.Start(); err != nil {
+		return -1, "", err
+	}
+
+	return cmd.Process.Pid, p.proxyURL, nil
+}
+
+// register is kataProxy register implementation for proxy interface.
+func (p *kataProxy) register(pod Pod) ([]ProxyInfo, string, error) {
+	var proxyInfos []ProxyInfo
+
+	for i := 0; i < len(pod.containers); i++ {
+		proxyInfo := ProxyInfo{}
+
+		proxyInfos = append(proxyInfos, proxyInfo)
+	}
+
+	return proxyInfos, p.proxyURL, nil
+}
+
+// unregister is kataProxy unregister implementation for proxy interface.
+func (p *kataProxy) unregister(pod Pod) error {
+	return nil
+}
+
+// connect is kataProxy connect implementation for proxy interface.
+func (p *kataProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
+	return ProxyInfo{}, p.proxyURL, nil
+}
+
+// disconnect is kataProxy disconnect implementation for proxy interface.
+func (p *kataProxy) disconnect() error {
+	return nil
+}
+
+// sendCmd is kataProxy sendCmd implementation for proxy interface.
+func (p *kataProxy) sendCmd(cmd interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/vendor/github.com/containers/virtcontainers/kata_proxy_test.go
+++ b/vendor/github.com/containers/virtcontainers/kata_proxy_test.go
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"testing"
+)
+
+var testKataProxyURL = "vmURL"
+
+func TestKataProxyRegister(t *testing.T) {
+	p := &kataProxy{
+		proxyURL: testKataProxyURL,
+	}
+
+	_, proxyURL, err := p.register(Pod{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if proxyURL != testKataProxyURL {
+		t.Fatalf("Got URL %q, expecting %q", proxyURL, testKataProxyURL)
+	}
+}
+
+func TestKataProxyUnregister(t *testing.T) {
+	p := &kataProxy{}
+
+	if err := p.unregister(Pod{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKataProxyConnect(t *testing.T) {
+	p := &kataProxy{
+		proxyURL: testKataProxyURL,
+	}
+
+	_, proxyURL, err := p.connect(Pod{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if proxyURL != testKataProxyURL {
+		t.Fatalf("Got URL %q, expecting %q", proxyURL, testKataProxyURL)
+	}
+}
+
+func TestKataProxyDisconnect(t *testing.T) {
+	p := &kataProxy{}
+
+	if err := p.disconnect(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKataProxySendCmd(t *testing.T) {
+	p := &kataProxy{}
+
+	if _, err := p.sendCmd(nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/vendor/github.com/containers/virtcontainers/no_proxy.go
+++ b/vendor/github.com/containers/virtcontainers/no_proxy.go
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+// This is the no proxy implementation of the proxy interface. This
+// is a generic implementation for any case (basically any agent),
+// where no actual proxy is needed. This happens when the combination
+// of the VM and the agent can handle multiple connections without
+// additional component to handle the multiplexing. Both the runtime
+// and the shim will connect to the agent through the VM, bypassing
+// the proxy model.
+// That's why this implementation is very generic, and all it does
+// is to provide both shim and runtime the correct URL to connect
+// directly to the VM.
+type noProxy struct {
+	vmURL string
+}
+
+// start is noProxy start implementation for proxy interface.
+func (p *noProxy) start(pod Pod) (int, string, error) {
+	url, err := pod.agent.vmURL()
+	if err != nil {
+		return -1, "", err
+	}
+
+	p.vmURL = url
+
+	if err := pod.agent.setProxyURL(url); err != nil {
+		return -1, "", err
+	}
+
+	return 0, p.vmURL, nil
+}
+
+// register is noProxy register implementation for proxy interface.
+func (p *noProxy) register(pod Pod) ([]ProxyInfo, string, error) {
+	var proxyInfos []ProxyInfo
+
+	for i := 0; i < len(pod.containers); i++ {
+		proxyInfo := ProxyInfo{}
+
+		proxyInfos = append(proxyInfos, proxyInfo)
+	}
+
+	return proxyInfos, p.vmURL, nil
+}
+
+// unregister is noProxy unregister implementation for proxy interface.
+func (p *noProxy) unregister(pod Pod) error {
+	return nil
+}
+
+// connect is noProxy connect implementation for proxy interface.
+func (p *noProxy) connect(pod Pod, createToken bool) (ProxyInfo, string, error) {
+	return ProxyInfo{}, p.vmURL, nil
+}
+
+// disconnect is noProxy disconnect implementation for proxy interface.
+func (p *noProxy) disconnect() error {
+	return nil
+}
+
+// sendCmd is noProxy sendCmd implementation for proxy interface.
+func (p *noProxy) sendCmd(cmd interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/vendor/github.com/containers/virtcontainers/no_proxy_test.go
+++ b/vendor/github.com/containers/virtcontainers/no_proxy_test.go
@@ -1,0 +1,98 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"testing"
+)
+
+var testNoProxyVMURL = "vmURL"
+
+func TestNoProxyStart(t *testing.T) {
+	pod := Pod{
+		agent: newAgent(NoopAgentType),
+	}
+
+	p := &noProxy{}
+
+	pid, vmURL, err := p.start(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vmURL != "" {
+		t.Fatalf("Got URL %q, expecting empty URL", vmURL)
+	}
+
+	if pid != 0 {
+		t.Fatal("Failure since returned PID should be 0")
+	}
+}
+
+func TestNoProxyRegister(t *testing.T) {
+	p := &noProxy{
+		vmURL: testNoProxyVMURL,
+	}
+
+	_, vmURL, err := p.register(Pod{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vmURL != testNoProxyVMURL {
+		t.Fatalf("Got URL %q, expecting %q", vmURL, testNoProxyVMURL)
+	}
+}
+
+func TestNoProxyUnregister(t *testing.T) {
+	p := &noProxy{}
+
+	if err := p.unregister(Pod{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNoProxyConnect(t *testing.T) {
+	p := &noProxy{
+		vmURL: testNoProxyVMURL,
+	}
+
+	_, vmURL, err := p.connect(Pod{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vmURL != testNoProxyVMURL {
+		t.Fatalf("Got URL %q, expecting %q", vmURL, testNoProxyVMURL)
+	}
+}
+
+func TestNoProxyDisconnect(t *testing.T) {
+	p := &noProxy{}
+
+	if err := p.disconnect(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNoProxySendCmd(t *testing.T) {
+	p := &noProxy{}
+
+	if _, err := p.sendCmd(nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/vendor/github.com/containers/virtcontainers/noop_agent.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent.go
@@ -30,6 +30,16 @@ func (n *noopAgent) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+// vmURL returns the VM URL from the Noop agent. It does nothing.
+func (n *noopAgent) vmURL() (string, error) {
+	return "", nil
+}
+
+// setProxyURL sets the URL of the proxy for the Noop agent. It does nothing.
+func (n *noopAgent) setProxyURL(url string) error {
+	return nil
+}
+
 // createPod is the Noop agent pod creation implementation. It does nothing.
 func (n *noopAgent) createPod(pod *Pod) error {
 	return nil

--- a/vendor/github.com/containers/virtcontainers/noop_agent_test.go
+++ b/vendor/github.com/containers/virtcontainers/noop_agent_test.go
@@ -30,6 +30,27 @@ func TestNoopAgentInit(t *testing.T) {
 	}
 }
 
+func TestNoopAgentVmURL(t *testing.T) {
+	n := &noopAgent{}
+
+	url, err := n.vmURL()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if url != "" {
+		t.Fatalf("URL should be empty: %s", url)
+	}
+}
+
+func TestNoopAgentProxyURL(t *testing.T) {
+	n := &noopAgent{}
+
+	if err := n.setProxyURL(""); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestNoopAgentExec(t *testing.T) {
 	n := &noopAgent{}
 	pod := &Pod{}

--- a/vendor/github.com/containers/virtcontainers/noop_proxy.go
+++ b/vendor/github.com/containers/virtcontainers/noop_proxy.go
@@ -16,6 +16,8 @@
 
 package virtcontainers
 
+// This is a dummy proxy implementation of the proxy interface, only
+// used for testing purpose.
 type noopProxy struct{}
 
 var noopProxyURL = "noopProxyURL"

--- a/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
@@ -173,19 +173,30 @@ type Process struct {
 	Rlimits []Rlimit `json:"rlimits,omitempty"`
 }
 
+// SystemMountsInfo describes additional information for system mounts that the agent
+// needs to handle
+type SystemMountsInfo struct {
+	// Indicates if /dev has been passed as a bind mount for the host /dev
+	BindMountDev bool `json:"bindMountDev"`
+
+	// Size of /dev/shm assigned on the host.
+	DevShmSize int `json:"devShmSize"`
+}
+
 // Container describes a container running on a pod.
 type Container struct {
-	ID            string              `json:"id"`
-	Rootfs        string              `json:"rootfs"`
-	Fstype        string              `json:"fstype,omitempty"`
-	Image         string              `json:"image"`
-	Addr          string              `json:"addr,omitempty"`
-	Volumes       []*VolumeDescriptor `json:"volumes,omitempty"`
-	Fsmap         []*FsmapDescriptor  `json:"fsmap,omitempty"`
-	Sysctl        map[string]string   `json:"sysctl,omitempty"`
-	Process       *Process            `json:"process"`
-	RestartPolicy string              `json:"restartPolicy"`
-	Initialize    bool                `json:"initialize"`
+	ID               string              `json:"id"`
+	Rootfs           string              `json:"rootfs"`
+	Fstype           string              `json:"fstype,omitempty"`
+	Image            string              `json:"image"`
+	Addr             string              `json:"addr,omitempty"`
+	Volumes          []*VolumeDescriptor `json:"volumes,omitempty"`
+	Fsmap            []*FsmapDescriptor  `json:"fsmap,omitempty"`
+	Sysctl           map[string]string   `json:"sysctl,omitempty"`
+	Process          *Process            `json:"process"`
+	RestartPolicy    string              `json:"restartPolicy"`
+	Initialize       bool                `json:"initialize"`
+	SystemMountsInfo SystemMountsInfo    `json:"systemMountsInfo"`
 }
 
 // IPAddress describes an IP address and its network mask.

--- a/vendor/github.com/containers/virtcontainers/pod.go
+++ b/vendor/github.com/containers/virtcontainers/pod.go
@@ -316,7 +316,7 @@ type PodConfig struct {
 	AgentConfig interface{}
 
 	ProxyType   ProxyType
-	ProxyConfig interface{}
+	ProxyConfig ProxyConfig
 
 	ShimType   ShimType
 	ShimConfig interface{}

--- a/vendor/github.com/containers/virtcontainers/qemu_test.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	ciaoQemu "github.com/ciao-project/ciao/qemu"
+	govmmQemu "github.com/intel/govmm/qemu"
 )
 
 func newQemuConfig() HypervisorConfig {
@@ -99,8 +99,8 @@ func TestQemuBuildKernelParamsFoo(t *testing.T) {
 	}
 }
 
-func testQemuAppend(t *testing.T, structure interface{}, expected []ciaoQemu.Device, devType deviceType, nestedVM bool) {
-	var devices []ciaoQemu.Device
+func testQemuAppend(t *testing.T, structure interface{}, expected []govmmQemu.Device, devType deviceType, nestedVM bool) {
+	var devices []govmmQemu.Device
 	q := &qemu{
 		nestedRun: nestedVM,
 	}
@@ -133,14 +133,14 @@ func TestQemuAppendVolume(t *testing.T) {
 	hostPath := "testHostPath"
 	nestedVM := true
 
-	expectedOut := []ciaoQemu.Device{
-		ciaoQemu.FSDevice{
-			Driver:        ciaoQemu.Virtio9P,
-			FSDriver:      ciaoQemu.Local,
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.FSDevice{
+			Driver:        govmmQemu.Virtio9P,
+			FSDriver:      govmmQemu.Local,
 			ID:            fmt.Sprintf("extra-9p-%s", mountTag),
 			Path:          hostPath,
 			MountTag:      mountTag,
-			SecurityModel: ciaoQemu.None,
+			SecurityModel: govmmQemu.None,
 			DisableModern: nestedVM,
 		},
 	}
@@ -160,10 +160,10 @@ func TestQemuAppendSocket(t *testing.T) {
 	name := "sh.hyper.channel.test"
 	nestedVM := true
 
-	expectedOut := []ciaoQemu.Device{
-		ciaoQemu.CharDevice{
-			Driver:   ciaoQemu.VirtioSerialPort,
-			Backend:  ciaoQemu.Socket,
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.CharDevice{
+			Driver:   govmmQemu.VirtioSerialPort,
+			Backend:  govmmQemu.Socket,
 			DeviceID: deviceID,
 			ID:       id,
 			Path:     hostPath,
@@ -187,13 +187,13 @@ func TestQemuAppendBlockDevice(t *testing.T) {
 	format := "raw"
 	nestedVM := true
 
-	expectedOut := []ciaoQemu.Device{
-		ciaoQemu.BlockDevice{
-			Driver:        ciaoQemu.VirtioBlock,
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.BlockDevice{
+			Driver:        govmmQemu.VirtioBlock,
 			ID:            id,
 			File:          "/root",
-			AIO:           ciaoQemu.Threads,
-			Format:        ciaoQemu.BlockDeviceFormat(format),
+			AIO:           govmmQemu.Threads,
+			Format:        govmmQemu.BlockDeviceFormat(format),
 			Interface:     "none",
 			DisableModern: nestedVM,
 		},
@@ -212,8 +212,8 @@ func TestQemuAppendVFIODevice(t *testing.T) {
 	nestedVM := true
 	bdf := "02:10.1"
 
-	expectedOut := []ciaoQemu.Device{
-		ciaoQemu.VFIODevice{
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.VFIODevice{
 			BDF: bdf,
 		},
 	}
@@ -233,23 +233,23 @@ func TestQemuAppendFSDevices(t *testing.T) {
 	volHostPath := "testVolHostPath"
 	nestedVM := true
 
-	expectedOut := []ciaoQemu.Device{
-		ciaoQemu.FSDevice{
-			Driver:        ciaoQemu.Virtio9P,
-			FSDriver:      ciaoQemu.Local,
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.FSDevice{
+			Driver:        govmmQemu.Virtio9P,
+			FSDriver:      govmmQemu.Local,
 			ID:            fmt.Sprintf("extra-9p-%s", fmt.Sprintf("%s.1", volMountTag)),
 			Path:          fmt.Sprintf("%s.1", volHostPath),
 			MountTag:      fmt.Sprintf("%s.1", volMountTag),
-			SecurityModel: ciaoQemu.None,
+			SecurityModel: govmmQemu.None,
 			DisableModern: nestedVM,
 		},
-		ciaoQemu.FSDevice{
-			Driver:        ciaoQemu.Virtio9P,
-			FSDriver:      ciaoQemu.Local,
+		govmmQemu.FSDevice{
+			Driver:        govmmQemu.Virtio9P,
+			FSDriver:      govmmQemu.Local,
 			ID:            fmt.Sprintf("extra-9p-%s", fmt.Sprintf("%s.2", volMountTag)),
 			Path:          fmt.Sprintf("%s.2", volHostPath),
 			MountTag:      fmt.Sprintf("%s.2", volMountTag),
-			SecurityModel: ciaoQemu.None,
+			SecurityModel: govmmQemu.None,
 			DisableModern: nestedVM,
 		},
 	}
@@ -289,15 +289,15 @@ func TestQemuAppendConsoles(t *testing.T) {
 	podID := "testPodID"
 	nestedVM := true
 
-	expectedOut := []ciaoQemu.Device{
-		ciaoQemu.SerialDevice{
-			Driver:        ciaoQemu.VirtioSerial,
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.SerialDevice{
+			Driver:        govmmQemu.VirtioSerial,
 			ID:            "serial0",
 			DisableModern: nestedVM,
 		},
-		ciaoQemu.CharDevice{
-			Driver:   ciaoQemu.Console,
-			Backend:  ciaoQemu.Socket,
+		govmmQemu.CharDevice{
+			Driver:   govmmQemu.Console,
+			Backend:  govmmQemu.Socket,
 			DeviceID: "console0",
 			ID:       "charconsole0",
 			Path:     filepath.Join(runStoragePath, podID, defaultConsole),
@@ -313,7 +313,7 @@ func TestQemuAppendConsoles(t *testing.T) {
 }
 
 func TestQemuAppendImage(t *testing.T) {
-	var devices []ciaoQemu.Device
+	var devices []govmmQemu.Device
 
 	qemuConfig := newQemuConfig()
 	q := &qemu{
@@ -331,10 +331,10 @@ func TestQemuAppendImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedOut := []ciaoQemu.Device{
-		ciaoQemu.Object{
-			Driver:   ciaoQemu.NVDIMM,
-			Type:     ciaoQemu.MemoryBackendFile,
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.Object{
+			Driver:   govmmQemu.NVDIMM,
+			Type:     govmmQemu.MemoryBackendFile,
 			DeviceID: "nv0",
 			ID:       "mem0",
 			MemPath:  q.config.ImagePath,
@@ -424,7 +424,7 @@ func TestQemuSetCPUResources(t *testing.T) {
 
 	q := &qemu{}
 
-	expectedOut := ciaoQemu.SMP{
+	expectedOut := govmmQemu.SMP{
 		CPUs:    uint32(vcpus),
 		Cores:   uint32(vcpus),
 		Sockets: uint32(1),
@@ -457,7 +457,7 @@ func TestQemuSetMemoryResources(t *testing.T) {
 	}
 	memMax := fmt.Sprintf("%dM", int(float64(hostMemKb)/1024)+maxMemoryOffset)
 
-	expectedOut := ciaoQemu.Memory{
+	expectedOut := govmmQemu.Memory{
 		Size:   "1000M",
 		Slots:  uint8(2),
 		MaxMem: memMax,
@@ -481,7 +481,7 @@ func TestQemuSetMemoryResources(t *testing.T) {
 	}
 }
 
-func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []ciaoQemu.Device, nestedVM bool) {
+func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []govmmQemu.Device, nestedVM bool) {
 	q := &qemu{
 		nestedRun: nestedVM,
 	}
@@ -501,14 +501,14 @@ func TestQemuAddDeviceFsDev(t *testing.T) {
 	hostPath := "testHostPath"
 	nestedVM := true
 
-	expectedOut := []ciaoQemu.Device{
-		ciaoQemu.FSDevice{
-			Driver:        ciaoQemu.Virtio9P,
-			FSDriver:      ciaoQemu.Local,
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.FSDevice{
+			Driver:        govmmQemu.Virtio9P,
+			FSDriver:      govmmQemu.Local,
 			ID:            fmt.Sprintf("extra-9p-%s", mountTag),
 			Path:          hostPath,
 			MountTag:      mountTag,
-			SecurityModel: ciaoQemu.None,
+			SecurityModel: govmmQemu.None,
 			DisableModern: nestedVM,
 		},
 	}
@@ -528,10 +528,10 @@ func TestQemuAddDeviceSerialPordDev(t *testing.T) {
 	name := "sh.hyper.channel.test"
 	nestedVM := true
 
-	expectedOut := []ciaoQemu.Device{
-		ciaoQemu.CharDevice{
-			Driver:   ciaoQemu.VirtioSerialPort,
-			Backend:  ciaoQemu.Socket,
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.CharDevice{
+			Driver:   govmmQemu.VirtioSerialPort,
+			Backend:  govmmQemu.Socket,
 			DeviceID: deviceID,
 			ID:       id,
 			Path:     hostPath,

--- a/vendor/github.com/containers/virtcontainers/sshd.go
+++ b/vendor/github.com/containers/virtcontainers/sshd.go
@@ -105,6 +105,16 @@ func (s *sshd) init(pod *Pod, config interface{}) error {
 	return nil
 }
 
+// vmURL returns VM URL from the sshd agent implementation.
+func (s *sshd) vmURL() (string, error) {
+	return "", nil
+}
+
+// setProxyURL sets proxy URL for the sshd agent implementation.
+func (s *sshd) setProxyURL(url string) error {
+	return nil
+}
+
 // createPod is the agent pod creation implementation for sshd.
 func (s *sshd) createPod(pod *Pod) error {
 	return nil


### PR DESCRIPTION
This is mainly for the changes introduces in hyperstart container
for specifying system mount information

Virtcontainers Shortlog:

71ce0c8 proxy: Implement Kata Containers proxy
8f9a2e0 proxy: Implement no_proxy generic case
2e2d33c agent: Introduce new functions to agent interface
05cec52 hyperstart: Change the path where rootfs is bind-mounted
d0051aa agent: Pass information about  the "-v /dev:/dev"  case
bdc815d mounts: Deduce additional information about system mounts
7c88153 vendor: switch to govmm

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>