### PR TITLE
vendor: Re-vendor virtcontainers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -7,7 +7,7 @@
     "pkg/hyperstart",
     "pkg/hyperstart/mock"
   ]
-  revision = "6bccdf63e8c47e294c9e320aaa1c7b30e35350ca"
+  revision = "c88890875e8d4ce31a0664d6a7e7ca637aae9045"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -53,6 +53,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7b7e510e5315b97f4d052809fa25d56f1bd9b457f2fed92f1ef7e24a88a76b48"
+  inputs-digest = "2deb5e3eeb8c9668a8452bc2ab1b2db2e28d1e49dce4890e74ecac915e8687af"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,7 @@
 
 [[constraint]]
   name = "github.com/containers/virtcontainers"
-  revision = "6bccdf63e8c47e294c9e320aaa1c7b30e35350ca"
+  revision = "c88890875e8d4ce31a0664d6a7e7ca637aae9045"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/vendor/github.com/containers/virtcontainers/Gopkg.lock
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.lock
@@ -10,10 +10,9 @@
   revision = "1d2a6a3ea132a86abd0731408b7dc34f2fc17d55"
 
 [[projects]]
-  branch = "master"
   name = "github.com/containerd/cri-containerd"
   packages = ["pkg/annotations"]
-  revision = "ca3b73899a159b17e49156f756d1c77e3b60bce4"
+  revision = "3d382e2f5dabe3bae62ceb9ded56bdee847008ee"
 
 [[projects]]
   name = "github.com/containernetworking/cni"
@@ -55,7 +54,6 @@
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -64,7 +62,8 @@
     "ptypes/duration",
     "ptypes/timestamp"
   ]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/intel/govmm"
@@ -77,7 +76,7 @@
     "protocols/client",
     "protocols/grpc"
   ]
-  revision = "11f8b0ad0a3bb5771b88cbccd0a9c7dca5fd8e56"
+  revision = "33eecb2a445f906811a5bc9713d2dafd10768d18"
 
 [[projects]]
   name = "github.com/kubernetes-incubator/cri-o"
@@ -142,7 +141,7 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "0fcca4842a8d74bfddc2c96a073bd2a4d2a7a2e8"
+  revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
 
 [[projects]]
   name = "golang.org/x/net"
@@ -166,7 +165,6 @@
   revision = "1d2aa6dbdea45adaaebb9905d0666e4537563829"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -184,13 +182,14 @@
     "unicode/norm",
     "unicode/rangetable"
   ]
-  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "a8101f21cf983e773d0c1133ebc5424792003214"
+  revision = "2c5e7ac708aaa719366570dd82bda44541ca2a63"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -222,6 +221,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "40c24a43bb5ecd05c62d6b80cbd752cf6dc6291cae217936fa288e1dbb39c09f"
+  inputs-digest = "e967c53b1d55018feac5c3db0e1c142cb63042311aac76206a47ce7c0cd8316c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/containers/virtcontainers/Gopkg.toml
+++ b/vendor/github.com/containers/virtcontainers/Gopkg.toml
@@ -60,7 +60,11 @@
 
 [[constraint]]
   name = "github.com/kata-containers/agent"
-  revision = "11f8b0ad0a3bb5771b88cbccd0a9c7dca5fd8e56"
+  revision = "33eecb2a445f906811a5bc9713d2dafd10768d18"
+
+[[constraint]]
+  name = "github.com/containerd/cri-containerd"
+  revision = "3d382e2f5dabe3bae62ceb9ded56bdee847008ee"
 
 [prune]
   non-go = true

--- a/vendor/github.com/containers/virtcontainers/README.md
+++ b/vendor/github.com/containers/virtcontainers/README.md
@@ -29,6 +29,7 @@ Table of Contents
       * [How to check if container uses devicemapper block device as its rootfs](#how-to-check-if-container-uses-devicemapper-block-device-as-its-rootfs)
    * [Devices](#devices)
       * [How to pass a device using VFIO-passthrough](#how-to-pass-a-device-using-vfio-passthrough)
+   * [Developers](#developers)
 
 # What is it ?
 
@@ -346,3 +347,8 @@ PCI devices. The driver for the device needs to be present within the
 Clear Containers kernel. If the driver is missing,  you can add it to your
 custom container kernel using the [osbuilder](https://github.com/clearcontainers/osbuilder)
 tooling.
+
+# Developers
+
+For information on how to build, develop and test `virtcontainers`, see the
+[developer documentation](documentation/Developers.md).

--- a/vendor/github.com/containers/virtcontainers/api_test.go
+++ b/vendor/github.com/containers/virtcontainers/api_test.go
@@ -883,6 +883,7 @@ func TestStatusPodSuccessfulStateReady(t *testing.T) {
 		DefaultMemSz:      defaultMemSzMiB,
 		DefaultBridges:    defaultBridges,
 		BlockDeviceDriver: defaultBlockDriver,
+		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 
 	expectedStatus := PodStatus{
@@ -938,6 +939,7 @@ func TestStatusPodSuccessfulStateRunning(t *testing.T) {
 		DefaultMemSz:      defaultMemSzMiB,
 		DefaultBridges:    defaultBridges,
 		BlockDeviceDriver: defaultBlockDriver,
+		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 
 	expectedStatus := PodStatus{

--- a/vendor/github.com/containers/virtcontainers/container_test.go
+++ b/vendor/github.com/containers/virtcontainers/container_test.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 	"testing"
 
+	vcAnnotations "github.com/containers/virtcontainers/pkg/annotations"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -280,4 +281,54 @@ func TestCheckPodRunningSuccessful(t *testing.T) {
 	}
 	err := c.checkPodRunning("test_cmd")
 	assert.Nil(t, err, "%v", err)
+}
+
+func TestContainerAddResources(t *testing.T) {
+	assert := assert.New(t)
+
+	c := &Container{}
+	err := c.addResources()
+	assert.Nil(err)
+
+	c.config = &ContainerConfig{Annotations: make(map[string]string)}
+	c.config.Annotations[vcAnnotations.ContainerTypeKey] = string(PodSandbox)
+	err = c.addResources()
+	assert.Nil(err)
+
+	c.config.Annotations[vcAnnotations.ContainerTypeKey] = string(PodContainer)
+	err = c.addResources()
+	assert.Nil(err)
+
+	c.config.Resources = ContainerResources{
+		CPUQuota:  5000,
+		CPUPeriod: 1000,
+	}
+	c.pod = &Pod{hypervisor: &mockHypervisor{}}
+	err = c.addResources()
+	assert.Nil(err)
+}
+
+func TestContainerRemoveResources(t *testing.T) {
+	assert := assert.New(t)
+
+	c := &Container{}
+	err := c.addResources()
+	assert.Nil(err)
+
+	c.config = &ContainerConfig{Annotations: make(map[string]string)}
+	c.config.Annotations[vcAnnotations.ContainerTypeKey] = string(PodSandbox)
+	err = c.removeResources()
+	assert.Nil(err)
+
+	c.config.Annotations[vcAnnotations.ContainerTypeKey] = string(PodContainer)
+	err = c.removeResources()
+	assert.Nil(err)
+
+	c.config.Resources = ContainerResources{
+		CPUQuota:  5000,
+		CPUPeriod: 1000,
+	}
+	c.pod = &Pod{hypervisor: &mockHypervisor{}}
+	err = c.removeResources()
+	assert.Nil(err)
 }

--- a/vendor/github.com/containers/virtcontainers/filesystem.go
+++ b/vendor/github.com/containers/virtcontainers/filesystem.go
@@ -88,7 +88,7 @@ const mountsFile = "mounts.json"
 const devicesFile = "devices.json"
 
 // dirMode is the permission bits used for creating a directory
-const dirMode = os.FileMode(0750)
+const dirMode = os.FileMode(0750) | os.ModeDir
 
 // storagePathSuffix is the suffix used for all storage paths
 const storagePathSuffix = "/virtcontainers/pods"
@@ -154,7 +154,7 @@ func (fs *filesystem) Logger() *logrus.Entry {
 func (fs *filesystem) createAllResources(pod Pod) (err error) {
 	for _, resource := range []podResource{stateFileType, configFileType} {
 		_, path, _ := fs.podURI(pod.id, resource)
-		err = os.MkdirAll(path, os.ModeDir)
+		err = os.MkdirAll(path, dirMode)
 		if err != nil {
 			return err
 		}
@@ -163,7 +163,7 @@ func (fs *filesystem) createAllResources(pod Pod) (err error) {
 	for _, container := range pod.containers {
 		for _, resource := range []podResource{stateFileType, configFileType} {
 			_, path, _ := fs.containerURI(pod.id, container.id, resource)
-			err = os.MkdirAll(path, os.ModeDir)
+			err = os.MkdirAll(path, dirMode)
 			if err != nil {
 				fs.deletePodResources(pod.id, nil)
 				return err

--- a/vendor/github.com/containers/virtcontainers/filesystem_test.go
+++ b/vendor/github.com/containers/virtcontainers/filesystem_test.go
@@ -80,16 +80,27 @@ func TestFilesystemCreateAllResourcesSuccessful(t *testing.T) {
 
 	for _, container := range contConfigs {
 		configPath := filepath.Join(configStoragePath, testPodID, container.ID)
-		_, err = os.Stat(configPath)
+		s, err := os.Stat(configPath)
 		if err != nil {
 			t.Fatal(err)
 		}
 
+		// Check we created the dirs with the correct mode
+		if s.Mode() != dirMode {
+			t.Fatal(fmt.Errorf("dirmode [%v] != expected [%v]", s.Mode(), dirMode))
+		}
+
 		runPath := filepath.Join(runStoragePath, testPodID, container.ID)
-		_, err = os.Stat(runPath)
+		s, err = os.Stat(runPath)
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// Check we created the dirs with the correct mode
+		if s.Mode() != dirMode {
+			t.Fatal(fmt.Errorf("dirmode [%v] != expected [%v]", s.Mode(), dirMode))
+		}
+
 	}
 }
 

--- a/vendor/github.com/containers/virtcontainers/hyperstart_agent.go
+++ b/vendor/github.com/containers/virtcontainers/hyperstart_agent.go
@@ -27,6 +27,7 @@ import (
 
 	proxyClient "github.com/clearcontainers/proxy/client"
 	"github.com/containers/virtcontainers/pkg/hyperstart"
+	ns "github.com/containers/virtcontainers/pkg/nsenter"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -314,7 +315,19 @@ func (h *hyper) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 		Process:   *hyperProcess,
 	}
 
-	process, err := prepareAndStartShim(pod, h.shim, c.id, token, h.state.URL, cmd)
+	enterNSList := []ns.Namespace{
+		{
+			PID:  c.process.Pid,
+			Type: ns.NSTypeNet,
+		},
+		{
+			PID:  c.process.Pid,
+			Type: ns.NSTypePID,
+		},
+	}
+
+	process, err := prepareAndStartShim(pod, h.shim, c.id,
+		token, h.state.URL, cmd, []ns.NSType{}, enterNSList)
 	if err != nil {
 		return nil, err
 	}
@@ -411,6 +424,13 @@ func (h *hyper) startOneContainer(pod Pod, c *Container) error {
 		Process: process,
 	}
 
+	if c.config.Resources.CPUQuota != 0 && c.config.Resources.CPUPeriod != 0 {
+		container.Constraints = hyperstart.Constraints{
+			CPUQuota:  c.config.Resources.CPUQuota,
+			CPUPeriod: c.config.Resources.CPUPeriod,
+		}
+	}
+
 	container.SystemMountsInfo.BindMountDev = c.systemMountsInfo.BindMountDev
 
 	if c.state.Fstype != "" {
@@ -488,7 +508,17 @@ func (h *hyper) createContainer(pod *Pod, c *Container) (*Process, error) {
 		return nil, err
 	}
 
-	return prepareAndStartShim(pod, h.shim, c.id, token, h.state.URL, c.config.Cmd)
+	createNSList := []ns.NSType{ns.NSTypePID}
+
+	enterNSList := []ns.Namespace{
+		{
+			Path: pod.networkNS.NetNsPath,
+			Type: ns.NSTypeNet,
+		},
+	}
+
+	return prepareAndStartShim(pod, h.shim, c.id, token,
+		h.state.URL, c.config.Cmd, createNSList, enterNSList)
 }
 
 // startContainer is the agent Container starting implementation for hyperstart.

--- a/vendor/github.com/containers/virtcontainers/hypervisor.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor.go
@@ -51,6 +51,9 @@ const (
 	defaultBlockDriver = VirtioSCSI
 )
 
+// In some architectures the maximum number of vCPUs depends on the number of physical cores.
+var defaultMaxQemuVCPUs = maxQemuVCPUs()
+
 // deviceType describes a virtualized device type.
 type deviceType int
 
@@ -81,6 +84,9 @@ const (
 
 	// vhostuserDev is a Vhost-user device type
 	vhostuserDev
+
+	// CPUDevice is CPU device type
+	cpuDev
 )
 
 // Set sets an hypervisor type based on the input string.
@@ -179,6 +185,9 @@ type HypervisorConfig struct {
 	// Pod configuration VMConfig.VCPUs overwrites this.
 	DefaultVCPUs uint32
 
+	//DefaultMaxVCPUs specifies the maximum number of vCPUs for the VM.
+	DefaultMaxVCPUs uint32
+
 	// DefaultMem specifies default memory size in MiB for the VM.
 	// Pod configuration VMConfig.Memory overwrites this.
 	DefaultMemSz uint32
@@ -235,6 +244,10 @@ func (conf *HypervisorConfig) valid() (bool, error) {
 
 	if conf.BlockDeviceDriver == "" {
 		conf.BlockDeviceDriver = defaultBlockDriver
+	}
+
+	if conf.DefaultMaxVCPUs == 0 {
+		conf.DefaultMaxVCPUs = defaultMaxQemuVCPUs
 	}
 
 	return true, nil

--- a/vendor/github.com/containers/virtcontainers/hypervisor_test.go
+++ b/vendor/github.com/containers/virtcontainers/hypervisor_test.go
@@ -181,6 +181,7 @@ func TestHypervisorConfigDefaults(t *testing.T) {
 		DefaultMemSz:      defaultMemSzMiB,
 		DefaultBridges:    defaultBridges,
 		BlockDeviceDriver: defaultBlockDriver,
+		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 	if reflect.DeepEqual(hypervisorConfig, hypervisorConfigDefaultsExpected) == false {
 		t.Fatal()

--- a/vendor/github.com/containers/virtcontainers/kata_agent.go
+++ b/vendor/github.com/containers/virtcontainers/kata_agent.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 
 	vcAnnotations "github.com/containers/virtcontainers/pkg/annotations"
+	ns "github.com/containers/virtcontainers/pkg/nsenter"
 	"github.com/containers/virtcontainers/pkg/uuid"
 	kataclient "github.com/kata-containers/agent/protocols/client"
 	"github.com/kata-containers/agent/protocols/grpc"
@@ -42,12 +43,13 @@ var (
 	defaultKataID               = "charch0"
 	errorMissingProxy           = errors.New("Missing proxy pointer")
 	errorMissingOCISpec         = errors.New("Missing OCI specification")
-	kataHostSharedDir           = "/tmp/kata-containers/shared/pods/"
-	kataGuestSharedDir          = "/tmp/kata-containers/shared/pods/"
+	kataHostSharedDir           = "/run/kata-containers/shared/pods/"
+	kataGuestSharedDir          = "/run/kata-containers/shared/containers/"
 	mountGuest9pTag             = "kataShared"
 	type9pFs                    = "9p"
 	devPath                     = "/dev"
 	vsockSocketScheme           = "vsock"
+	kataBlkDevType              = "blk"
 )
 
 // KataAgentConfig is a structure storing information needed
@@ -297,7 +299,19 @@ func (k *kataAgent) exec(pod *Pod, c Container, cmd Cmd) (*Process, error) {
 		return nil, err
 	}
 
-	return prepareAndStartShim(pod, k.shim, c.id, req.ExecId, k.state.URL, cmd)
+	enterNSList := []ns.Namespace{
+		{
+			PID:  c.process.Pid,
+			Type: ns.NSTypeNet,
+		},
+		{
+			PID:  c.process.Pid,
+			Type: ns.NSTypePID,
+		},
+	}
+
+	return prepareAndStartShim(pod, k.shim, c.id, req.ExecId,
+		k.state.URL, cmd, []ns.NSType{}, enterNSList)
 }
 
 func (k *kataAgent) generateInterfacesAndRoutes(networkNS NetworkNamespace) ([]*grpc.Interface, []*grpc.Route, error) {
@@ -569,7 +583,8 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 		return nil, errorMissingOCISpec
 	}
 
-	var containerStorage []*grpc.Storage
+	var ctrStorages []*grpc.Storage
+	var ctrDevices []*grpc.Device
 
 	// The rootfs storage volume represents the container rootfs
 	// mount point inside the guest.
@@ -579,7 +594,8 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 	rootfs := &grpc.Storage{}
 
 	// This is the guest absolute root path for that container.
-	rootPath := filepath.Join(kataGuestSharedDir, c.id, rootfsDir)
+	rootPathParent := filepath.Join(kataGuestSharedDir, c.id)
+	rootPath := filepath.Join(rootPathParent, rootfsDir)
 
 	if c.state.Fstype != "" {
 		// This is a block based device rootfs.
@@ -588,16 +604,34 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 		if err != nil {
 			return nil, err
 		}
+		virtPath := filepath.Join(devPath, driveName)
 
-		rootfs.Source = filepath.Join(devPath, driveName)
-		rootfs.MountPoint = rootPath // Should we remove the "rootfs" suffix?
+		// Create a new device with empty ContainerPath so that we get
+		// the device being waited for by the agent inside the VM,
+		// without trying to match and update it into the OCI spec list
+		// of actual devices. The device corresponding to the rootfs is
+		// a very specific case.
+		rootfsDevice := &grpc.Device{
+			Type:          kataBlkDevType,
+			VmPath:        virtPath,
+			ContainerPath: "",
+		}
+
+		ctrDevices = append(ctrDevices, rootfsDevice)
+
+		rootfs.Source = virtPath
+		rootfs.MountPoint = rootPathParent
 		rootfs.Fstype = c.state.Fstype
+
+		if c.state.Fstype == "xfs" {
+			rootfs.Options = []string{"nouuid"}
+		}
 
 		// Add rootfs to the list of container storage.
 		// We only need to do this for block based rootfs, as we
 		// want the agent to mount it into the right location
-		// (/tmp/kata-containers/shared/pods/podID/ctrID/
-		containerStorage = append(containerStorage, rootfs)
+		// (kataGuestSharedDir/ctrID/
+		ctrStorages = append(ctrStorages, rootfs)
 
 	} else {
 		// This is not a block based device rootfs.
@@ -605,9 +639,9 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 		// shared drive between the host and the guest.
 		// With 9pfs we don't need to ask the agent to
 		// mount the rootfs as the shared directory
-		// (/tmp/kata-containers/shared/pods/) is already
-		// mounted in the guest. We only need to mount the
-		// rootfs from the host and it will show up in the guest.
+		// (kataGuestSharedDir) is already mounted in the
+		// guest. We only need to mount the rootfs from
+		// the host and it will show up in the guest.
 		if err := bindMountContainerRootfs(kataHostSharedDir, pod.id, c.id, c.rootFs, false); err != nil {
 			bindUnmountAllRootfs(kataHostSharedDir, *pod)
 			return nil, err
@@ -652,18 +686,20 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 			continue
 		}
 
-		deviceStorage := &grpc.Storage{
-			Source:     d.VirtPath,
-			MountPoint: d.DeviceInfo.ContainerPath,
+		kataDevice := &grpc.Device{
+			Type:          kataBlkDevType,
+			VmPath:        d.VirtPath,
+			ContainerPath: d.DeviceInfo.ContainerPath,
 		}
 
-		containerStorage = append(containerStorage, deviceStorage)
+		ctrDevices = append(ctrDevices, kataDevice)
 	}
 
 	req := &grpc.CreateContainerRequest{
 		ContainerId: c.id,
 		ExecId:      c.id,
-		Storages:    containerStorage,
+		Storages:    ctrStorages,
+		Devices:     ctrDevices,
 		OCI:         grpcSpec,
 	}
 
@@ -671,7 +707,17 @@ func (k *kataAgent) createContainer(pod *Pod, c *Container) (*Process, error) {
 		return nil, err
 	}
 
-	return prepareAndStartShim(pod, k.shim, c.id, req.ExecId, k.state.URL, c.config.Cmd)
+	createNSList := []ns.NSType{ns.NSTypePID}
+
+	enterNSList := []ns.Namespace{
+		{
+			Path: pod.networkNS.NetNsPath,
+			Type: ns.NSTypeNet,
+		},
+	}
+
+	return prepareAndStartShim(pod, k.shim, c.id, req.ExecId,
+		k.state.URL, c.config.Cmd, createNSList, enterNSList)
 }
 
 func (k *kataAgent) startContainer(pod Pod, c *Container) error {

--- a/vendor/github.com/containers/virtcontainers/network.go
+++ b/vendor/github.com/containers/virtcontainers/network.go
@@ -1257,8 +1257,10 @@ func createEndpointsFromScan(networkNSPath string, config NetworkConfig) ([]Endp
 				cnmLogger().WithField("interface", netInfo.Iface.Name).Info("Physical network interface found")
 				endpoint, err = createPhysicalEndpoint(netInfo)
 			} else {
+				var socketPath string
+
 				// Check if this is a dummy interface which has a vhost-user socket associated with it
-				socketPath, err := vhostUserSocketPath(netInfo)
+				socketPath, err = vhostUserSocketPath(netInfo)
 				if err != nil {
 					return err
 				}

--- a/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
+++ b/vendor/github.com/containers/virtcontainers/pkg/hyperstart/types.go
@@ -202,6 +202,16 @@ type SystemMountsInfo struct {
 	DevShmSize int `json:"devShmSize"`
 }
 
+// Constraints describes the constrains for a container
+type Constraints struct {
+	// CPUQuota specifies the total amount of time in microseconds
+	// The number of microseconds per CPUPeriod that the container is guaranteed CPU access
+	CPUQuota int64
+
+	// CPUPeriod specifies the CPU CFS scheduler period of time in microseconds
+	CPUPeriod uint64
+}
+
 // Container describes a container running on a pod.
 type Container struct {
 	ID               string              `json:"id"`
@@ -216,6 +226,7 @@ type Container struct {
 	RestartPolicy    string              `json:"restartPolicy"`
 	Initialize       bool                `json:"initialize"`
 	SystemMountsInfo SystemMountsInfo    `json:"systemMountsInfo"`
+	Constraints      Constraints         `json:"constraints"`
 }
 
 // IPAddress describes an IP address and its network mask.

--- a/vendor/github.com/containers/virtcontainers/qemu_amd64.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_amd64.go
@@ -78,6 +78,11 @@ var supportedQemuMachines = []govmmQemu.Machine{
 	},
 }
 
+// returns the maximum number of vCPUs supported
+func maxQemuVCPUs() uint32 {
+	return uint32(240)
+}
+
 func newQemuArch(machineType string) qemuArch {
 	if machineType == "" {
 		machineType = defaultQemuMachineType

--- a/vendor/github.com/containers/virtcontainers/qemu_arch_base.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_arch_base.go
@@ -213,6 +213,7 @@ func (q *qemuArchBase) cpuTopology(vcpus uint32) govmmQemu.SMP {
 		Sockets: vcpus,
 		Cores:   defaultCores,
 		Threads: defaultThreads,
+		MaxCPUs: defaultMaxQemuVCPUs,
 	}
 
 	return smp

--- a/vendor/github.com/containers/virtcontainers/qemu_arm64.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_arm64.go
@@ -16,7 +16,11 @@
 
 package virtcontainers
 
-import govmmQemu "github.com/intel/govmm/qemu"
+import (
+	"runtime"
+
+	govmmQemu "github.com/intel/govmm/qemu"
+)
 
 type qemuArm64 struct {
 	// inherit from qemuArchBase, overwrite methods if needed
@@ -44,6 +48,11 @@ var supportedQemuMachines = []govmmQemu.Machine{
 		Type:    QemuVirt,
 		Options: defaultQemuMachineOptions,
 	},
+}
+
+// returns the maximum number of vCPUs supported
+func maxQemuVCPUs() uint32 {
+	return uint32(runtime.NumCPU())
 }
 
 func newQemuArch(machineType string) qemuArch {

--- a/vendor/github.com/containers/virtcontainers/qemu_test.go
+++ b/vendor/github.com/containers/virtcontainers/qemu_test.go
@@ -37,6 +37,7 @@ func newQemuConfig() HypervisorConfig {
 		DefaultMemSz:      defaultMemSzMiB,
 		DefaultBridges:    defaultBridges,
 		BlockDeviceDriver: defaultBlockDriver,
+		DefaultMaxVCPUs:   defaultMaxQemuVCPUs,
 	}
 }
 
@@ -142,6 +143,7 @@ func TestQemuCPUTopology(t *testing.T) {
 		Sockets: uint32(vcpus),
 		Cores:   defaultCores,
 		Threads: defaultThreads,
+		MaxCPUs: defaultMaxQemuVCPUs,
 	}
 
 	vmConfig := Resources{

--- a/vendor/github.com/containers/virtcontainers/utils.go
+++ b/vendor/github.com/containers/virtcontainers/utils.go
@@ -96,3 +96,18 @@ func writeToFile(path string, data []byte) error {
 
 	return nil
 }
+
+// ConstraintsToVCPUs converts CPU quota and period to vCPUs
+func ConstraintsToVCPUs(quota int64, period uint64) uint {
+	if quota != 0 && period != 0 {
+		// Use some math magic to round up to the nearest whole vCPU
+		// (that is, a partial part of a quota request ends up assigning
+		// a whole vCPU, for instance, a request of 1.5 'cpu quotas'
+		// will give 2 vCPUs).
+		// This also has the side effect that we will always allocate
+		// at least 1 vCPU.
+		return uint((uint64(quota) + (period - 1)) / period)
+	}
+
+	return 0
+}

--- a/vendor/github.com/containers/virtcontainers/utils_test.go
+++ b/vendor/github.com/containers/virtcontainers/utils_test.go
@@ -162,3 +162,20 @@ func TestWriteToFile(t *testing.T) {
 
 	assert.True(t, reflect.DeepEqual(testData, data))
 }
+
+func TestConstraintsToVCPUs(t *testing.T) {
+	assert := assert.New(t)
+
+	vcpus := ConstraintsToVCPUs(0, 100)
+	assert.Zero(vcpus)
+
+	vcpus = ConstraintsToVCPUs(100, 0)
+	assert.Zero(vcpus)
+
+	expectedVCPUs := uint(4)
+	vcpus = ConstraintsToVCPUs(4000, 1000)
+	assert.Equal(expectedVCPUs, vcpus)
+
+	vcpus = ConstraintsToVCPUs(4000, 1200)
+	assert.Equal(expectedVCPUs, vcpus)
+}


### PR DESCRIPTION
Bring the CPU constraints changes.

12f35ce qemu: enable CPU hotplug
925a70c pod: hot add/remove vCPUs before starting containers
4a84438 qemu: Add support for CPU hot add/remove
c17c48d vendor: Constraint containerd vendoring
c9996f3 filesystem: set correct access mode for pod dir tree
4f9cb18 kata_agent: Add nouuid option for xfs filesystem
085848b kata_agent: Provide hotplugged device the right rootfs path
9ef18a6 kata_agent: Update host and guest paths for Kata
2c88b8e kata_agent: Wait for rootfs if it is a hotplugged device
15a4d17 kata_agent: Support block device passthrough
fd5b27f vendor: Update Kata agent protocol
0519e89 check: lint: ineffassign in qemu.go
ae661c5 network: Fix lint errors
5c73774 shim: Start shims inside PID namespace
6d7f6e5 shim: Add ability to enter any set of namespaces
f318b77 shim: Add the ability to spawn the shim in new namespaces
fefb087 pkg: nsenter: Introduce a generic nsenter package
43c05c2 utils: setup: Add some more prereq checks to the setup script.
1a25bad docs: developers: Add some developer docs

Fixes #219

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>